### PR TITLE
Changed client module package naming

### DIFF
--- a/examples/leader-example/src/main/scala/com/coralogix/zio/k8s/examples/leader/LeaderExample.scala
+++ b/examples/leader-example/src/main/scala/com/coralogix/zio/k8s/examples/leader/LeaderExample.scala
@@ -1,12 +1,9 @@
 package com.coralogix.zio.k8s.examples.leader
 
-import com.coralogix.zio.k8s.client.K8sFailure
 import com.coralogix.zio.k8s.client.config._
-import com.coralogix.zio.k8s.client.configmaps.v1.ConfigMaps
-import com.coralogix.zio.k8s.client.configmaps.{ v1 => configmaps }
-import com.coralogix.zio.k8s.client.model.K8sNamespace
-import com.coralogix.zio.k8s.client.pods.v1.Pods
-import com.coralogix.zio.k8s.client.pods.{ v1 => pods }
+import com.coralogix.zio.k8s.client.v1.configmaps.ConfigMaps
+import com.coralogix.zio.k8s.client.v1.{ configmaps, pods }
+import com.coralogix.zio.k8s.client.v1.pods.Pods
 import com.coralogix.zio.k8s.operator.Leader
 import zio._
 import zio.blocking.Blocking

--- a/zio-k8s-codegen/src/main/scala/com/coralogix/zio/k8s/codegen/K8sResourceCodegen.scala
+++ b/zio-k8s-codegen/src/main/scala/com/coralogix/zio/k8s/codegen/K8sResourceCodegen.scala
@@ -114,7 +114,7 @@ class K8sResourceCodegen(val logger: sbt.Logger)
       _ <- ZIO.effect(logger.info(s"Generating package code for ${resource.id}"))
 
       groupName = groupNameToPackageName(resource.gvk.group)
-      pkg       = (clientRoot ++ groupName) :+ resource.plural :+ resource.gvk.version
+      pkg       = (clientRoot ++ groupName) :+ resource.gvk.version :+ resource.plural
 
       (entityPkg, entity) = splitName(resource.modelName)
 

--- a/zio-k8s-codegen/src/shared/scala/com/coralogix/zio/k8s/codegen/internal/ClientModuleGenerator.scala
+++ b/zio-k8s-codegen/src/shared/scala/com/coralogix/zio/k8s/codegen/internal/ClientModuleGenerator.scala
@@ -170,7 +170,7 @@ trait ClientModuleGenerator {
           }
           val typeAlias = q"""type ${typeAliasT} = $typeAliasRhs"""
 
-          q"""package $basePackage.$moduleName {
+          q"""package $basePackage.$ver {
 
           $entityImport
           import com.coralogix.zio.k8s.model.pkg.apis.meta.v1._
@@ -189,7 +189,7 @@ trait ClientModuleGenerator {
           import zio.stream.{ZStream, ZTransducer}
           import zio.{ Has, Task, ZIO, ZLayer }
 
-          package object $ver {
+          package object $moduleName {
             $typeAlias
 
             def getAll(
@@ -345,7 +345,7 @@ trait ClientModuleGenerator {
           }
           val typeAlias = q"""type ${typeAliasT} = $typeAliasRhs"""
 
-          q"""package $basePackage.$moduleName {
+          q"""package $basePackage.$ver {
 
           $entityImport
           import com.coralogix.zio.k8s.model.pkg.apis.meta.v1._
@@ -364,7 +364,7 @@ trait ClientModuleGenerator {
           import zio.stream.{ZStream, ZTransducer}
           import zio.{ Has, Task, ZIO, ZLayer }
 
-          package object $ver {
+          package object $moduleName {
             $typeAlias
 
             def getAll(

--- a/zio-k8s-codegen/src/shared/scala/com/coralogix/zio/k8s/codegen/internal/Conversions.scala
+++ b/zio-k8s-codegen/src/shared/scala/com/coralogix/zio/k8s/codegen/internal/Conversions.scala
@@ -1,12 +1,17 @@
 package com.coralogix.zio.k8s.codegen.internal
 
 object Conversions {
-  def groupNameToPackageName(groupName: String): Vector[String] =
-    groupName
+  def groupNameToPackageName(groupName: String): Vector[String] = {
+    val base = groupName
       .split('.')
       .filter(_.nonEmpty)
       .reverse
       .toVector
+
+    if (base.length > 2 && base(0) == "io" && base(1) == "k8s")
+      base.drop(2)
+    else base
+  }
 
   def splitName(name: String): (Vector[String], String) = {
     val parts =

--- a/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-2/src/main/scala/Test.scala
+++ b/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-2/src/main/scala/Test.scala
@@ -1,5 +1,5 @@
 import com.coralogix.zio.k8s.client.com.example.stable.definitions.crontab.v1.CronTab
-import com.coralogix.zio.k8s.client.com.example.stable.crontabs.{v1 => crontabs}
+import com.coralogix.zio.k8s.client.com.example.stable.v1.crontabs
 import com.coralogix.zio.k8s.model.autoscaling.v1.Scale
 import com.coralogix.zio.k8s.client.model.K8sNamespace
 import com.coralogix.zio.k8s.client.K8sFailure

--- a/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Leader.scala
+++ b/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Leader.scala
@@ -1,16 +1,15 @@
 package com.coralogix.zio.k8s.operator
 
-import com.coralogix.zio.k8s.client.{ K8sFailure, NamespacedResource }
+import com.coralogix.zio.k8s.client.{ DecodedFailure, K8sFailure }
 import com.coralogix.zio.k8s.client.K8sFailure.syntax._
-import com.coralogix.zio.k8s.client.configmaps.{ v1 => configmaps }
-import com.coralogix.zio.k8s.client.configmaps.v1.ConfigMaps
 import com.coralogix.zio.k8s.client.model.K8sNamespace
-import com.coralogix.zio.k8s.client.pods.v1.Pods
-import com.coralogix.zio.k8s.client.pods.{ v1 => pods }
+import com.coralogix.zio.k8s.client.v1.configmaps.ConfigMaps
+import com.coralogix.zio.k8s.client.v1.{ configmaps, pods }
+import com.coralogix.zio.k8s.client.v1.pods.Pods
 import com.coralogix.zio.k8s.model.core.v1.{ ConfigMap, Pod }
-import com.coralogix.zio.k8s.model.pkg.apis.meta.v1.ObjectMeta
-import com.coralogix.zio.k8s.operator.OperatorLogging.logFailure
+import com.coralogix.zio.k8s.model.pkg.apis.meta.v1.{ DeleteOptions, ObjectMeta }
 import com.coralogix.zio.k8s.operator.OperatorFailure.k8sFailureToThrowable
+import com.coralogix.zio.k8s.operator.OperatorLogging.logFailure
 import zio._
 import zio.blocking.Blocking
 import zio.clock._
@@ -19,8 +18,6 @@ import zio.logging._
 import zio.nio.core.file.Path
 import zio.nio.file.Files
 import zio.system._
-import com.coralogix.zio.k8s.model.pkg.apis.meta.v1.DeleteOptions
-import com.coralogix.zio.k8s.client.DecodedFailure
 
 import java.io.IOException
 

--- a/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Registration.scala
+++ b/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Registration.scala
@@ -2,11 +2,11 @@ package com.coralogix.zio.k8s.operator
 
 import com.coralogix.zio.k8s.client.K8sFailure
 import K8sFailure.syntax._
-import com.coralogix.zio.k8s.client.io.k8s.apiextensions.customresourcedefinitions.{ v1 => crd }
+import com.coralogix.zio.k8s.client.apiextensions.v1.{ customresourcedefinitions => crd }
 import com.coralogix.zio.k8s.client.model.ResourceMetadata
 import zio.ZIO
 import zio.blocking.Blocking
-import com.coralogix.zio.k8s.client.io.k8s.apiextensions.customresourcedefinitions.v1.CustomResourceDefinitions
+import com.coralogix.zio.k8s.client.apiextensions.v1.customresourcedefinitions.CustomResourceDefinitions
 import com.coralogix.zio.k8s.model.pkg.apis.apiextensions.v1.CustomResourceDefinition
 import zio.logging.{ log, Logging }
 


### PR DESCRIPTION
Changes the client module package naming as described in #75 

This makes it better in sync with the package names of the generated models and makes the user code nicer as the actual plural resource name is used for the leaf package object, not the version.