### PR TITLE
Made the module layout more like the official recommended one

### DIFF
--- a/examples/leader-example/src/main/scala/com/coralogix/zio/k8s/examples/leader/LeaderExample.scala
+++ b/examples/leader-example/src/main/scala/com/coralogix/zio/k8s/examples/leader/LeaderExample.scala
@@ -2,10 +2,8 @@ package com.coralogix.zio.k8s.examples.leader
 
 import com.coralogix.zio.k8s.client._
 import com.coralogix.zio.k8s.client.config._
-import com.coralogix.zio.k8s.client.kubernetes
 import com.coralogix.zio.k8s.client.kubernetes.Kubernetes
 import com.coralogix.zio.k8s.client.v1.configmaps.ConfigMaps
-import com.coralogix.zio.k8s.client.v1.{ configmaps, pods }
 import com.coralogix.zio.k8s.client.v1.pods.Pods
 import com.coralogix.zio.k8s.operator.Leader
 import zio._
@@ -38,8 +36,8 @@ object LeaderExample extends App {
     val cluster = (Blocking.any ++ config.narrow(_.cluster)) >>> k8sCluster
 
     // Pods and ConfigMaps API
-    val k8s = (cluster ++ client) >>> kubernetes.live
-    //val k8s = (cluster ++ client) >>> (pods.live ++ configmaps.live)
+    val k8s = (cluster ++ client) >>> Kubernetes.live
+    // val k8s = (cluster ++ client) >>> (Pods.live ++ ConfigMaps.live)
 
     // Example code
     example()

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/package.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/package.scala
@@ -1,11 +1,11 @@
 package com.coralogix.zio.k8s
 
-import com.coralogix.zio.k8s.client.kubernetes.{ Kubernetes, KubernetesApi }
+import com.coralogix.zio.k8s.client.kubernetes.Kubernetes
 import zio.{ Has, Tag, ZLayer }
 
 package object client {
   final implicit class K8sApiLayerOps[R, E, A](val self: ZLayer[R, E, Kubernetes]) extends AnyVal {
-    def narrow[B: Tag](f: KubernetesApi => B): ZLayer[R, E, Has[B]] =
+    def narrow[B: Tag](f: Kubernetes.Api => B): ZLayer[R, E, Has[B]] =
       self.map(a => Has(f(a.get)))
   }
 }


### PR DESCRIPTION
The generated modules now have the same structure as documented on https://zio.dev/docs/howto/howto_use_layers


```scala
package object xs {
  type Xs = Has[Xs.Service]
  object Xs  {
    trait Service
    class Live
   
    val live: ZLayer
    val any: ZLayer
  }

  // acecssor defs
}
```