### PR TITLE
Change EventProcessor type to a trait

### DIFF
--- a/docs/operator/operator.md
+++ b/docs/operator/operator.md
@@ -56,11 +56,9 @@ import zio.logging.Logging
 
 val operator2 = 
     Operator.namespaced(
-        EventProcessorOps(eventProcessor) @@ logEvents
+        eventProcessor @@ logEvents
     )(namespace = None, buffer = 1024)
 ```
-
-**NOTE**: Having to explicitly wrap in the `EventProcessorOps` is a temporary regression and should not be necessary. Will be fixed.
 
 ### Defining an aspect
 In this example we define another aspect for monitoring the _event processing time_ and the number of different events processed with _Prometheus_ metrics using the [zio-metrics](https://zio.github.io/zio-metrics/) library.
@@ -130,7 +128,7 @@ def metered[T, E](operatorMetrics: OperatorMetrics): Aspect[Clock, E, T] =
 
 def operator3(metrics: OperatorMetrics) = 
     Operator.namespaced(
-        EventProcessorOps(eventProcessor) @@ logEvents @@ metered(metrics)
+        eventProcessor @@ logEvents @@ metered(metrics)
     )(namespace = None, buffer = 1024)
 ```
 

--- a/docs/operator/operator.md
+++ b/docs/operator/operator.md
@@ -8,8 +8,9 @@ title:  "Implementing operators"
 The library defines an `Operator` by providing an `EventProcessor`:
 
 ```scala
-type EventProcessor[R, E, T] =
-    (OperatorContext, TypedWatchEvent[T]) => ZIO[R, OperatorFailure[E], Unit]
+trait EventProcessor[-R, +E, T] {
+  def apply(context: OperatorContext, event: TypedWatchEvent[T]): ZIO[R, OperatorFailure[E], Unit]
+}
 ```
 
 To start an operator, use either the `Operator.cluster` or `Operator.namespaced` functions:

--- a/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Operator.scala
+++ b/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Operator.scala
@@ -1,14 +1,19 @@
 package com.coralogix.zio.k8s.operator
 
-import com.coralogix.zio.k8s.client.model.{K8sNamespace, K8sResourceType, ResourceMetadata, TypedWatchEvent}
-import com.coralogix.zio.k8s.client.{ClusterResource, K8sFailure, NamespacedResource, NotFound}
-import com.coralogix.zio.k8s.operator.Operator.{EventProcessor, OperatorContext}
+import com.coralogix.zio.k8s.client.model.{
+  K8sNamespace,
+  K8sResourceType,
+  ResourceMetadata,
+  TypedWatchEvent
+}
+import com.coralogix.zio.k8s.client.{ ClusterResource, K8sFailure, NamespacedResource, NotFound }
+import com.coralogix.zio.k8s.operator.Operator.{ EventProcessor, OperatorContext }
 import com.coralogix.zio.k8s.operator.OperatorLogging._
 import izumi.reflect.Tag
 import zio._
 import zio.clock.Clock
 import zio.duration.durationInt
-import zio.logging.{Logging, log}
+import zio.logging.{ log, Logging }
 import zio.stream.ZStream
 
 /** Core implementation of the operator logic.

--- a/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Operator.scala
+++ b/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/Operator.scala
@@ -1,19 +1,14 @@
 package com.coralogix.zio.k8s.operator
 
-import com.coralogix.zio.k8s.client.model.{
-  K8sNamespace,
-  K8sResourceType,
-  ResourceMetadata,
-  TypedWatchEvent
-}
-import com.coralogix.zio.k8s.client.{ ClusterResource, K8sFailure, NamespacedResource, NotFound }
-import com.coralogix.zio.k8s.operator.Operator.{ EventProcessor, OperatorContext }
+import com.coralogix.zio.k8s.client.model.{K8sNamespace, K8sResourceType, ResourceMetadata, TypedWatchEvent}
+import com.coralogix.zio.k8s.client.{ClusterResource, K8sFailure, NamespacedResource, NotFound}
+import com.coralogix.zio.k8s.operator.Operator.{EventProcessor, OperatorContext}
 import com.coralogix.zio.k8s.operator.OperatorLogging._
 import izumi.reflect.Tag
 import zio._
 import zio.clock.Clock
 import zio.duration.durationInt
-import zio.logging.{ log, Logging }
+import zio.logging.{Logging, log}
 import zio.stream.ZStream
 
 /** Core implementation of the operator logic.
@@ -147,8 +142,12 @@ object Operator {
       }
   }
 
-  type EventProcessor[R, E, T] =
-    (OperatorContext, TypedWatchEvent[T]) => ZIO[R, OperatorFailure[E], Unit]
+  trait EventProcessor[-R, +E, T] { self =>
+    def apply(context: OperatorContext, event: TypedWatchEvent[T]): ZIO[R, OperatorFailure[E], Unit]
+
+    def @@[R1 <: R, E1 >: E](aspect: Aspect[R1, E1, T]): EventProcessor[R1, E1, T] =
+      aspect[R1, E1](self)
+  }
 
   def namespaced[R: Tag, E, T: Tag: ResourceMetadata](
     eventProcessor: EventProcessor[R, E, T]
@@ -185,13 +184,6 @@ object Operator {
         ): EventProcessor[R2, E2, T] =
           that(self(f))
       }
-  }
-
-  implicit class EventProcessorOps[R, E, T](
-    eventProcessor: EventProcessor[R, E, T]
-  ) {
-    def @@[R1 <: R, E1 >: E](aspect: Aspect[R1, E1, T]): EventProcessor[R1, E1, T] =
-      aspect[R1, E1](eventProcessor)
   }
 
   final class ProvideSomeLayer[R0 <: Has[_], R, E, T](private val self: Operator[R, E, T])

--- a/zio-k8s-operator/src/test/scala/com/coralogix/zio/k8s/operator/OperatorAspectSpec.scala
+++ b/zio-k8s-operator/src/test/scala/com/coralogix/zio/k8s/operator/OperatorAspectSpec.scala
@@ -1,0 +1,38 @@
+package com.coralogix.zio.k8s.operator
+
+import com.coralogix.zio.k8s.client.model._
+import com.coralogix.zio.k8s.model.core.v1.Pod
+import com.coralogix.zio.k8s.operator.Operator._
+import com.coralogix.zio.k8s.operator.aspects.logEvents
+import zio.ZIO
+import zio.clock.Clock
+import zio.test.environment.TestEnvironment
+import zio.test.{ assertCompletes, DefaultRunnableSpec, ZSpec }
+
+object OperatorAspectSpec extends DefaultRunnableSpec {
+  sealed trait CustomOperatorFailures
+
+  override def spec: ZSpec[TestEnvironment, Any] =
+    suite("Operator aspects")(
+      test("can @@ the built-in logEvents aspect") {
+        val eventProcessor: EventProcessor[Clock, CustomOperatorFailures, Pod] =
+          (ctx, event) =>
+            event match {
+              case Reseted        =>
+                ZIO.unit
+              case Added(item)    =>
+                ZIO.unit
+              case Modified(item) =>
+                ZIO.unit
+              case Deleted(item)  =>
+                ZIO.unit
+            }
+
+        val _ = Operator.namespaced(
+          eventProcessor @@ logEvents
+        )(namespace = None, buffer = 1024)
+
+        assertCompletes
+      }
+    )
+}


### PR DESCRIPTION
This removes the need to the implicit `EventProcessorOps` and fixes #92 