### PR TITLE
Fix reported CRD problems

### DIFF
--- a/zio-k8s-crd/src/main/scala/com/coralogix/zio/k8s/crd/guardrail/K8sCodegenContext.scala
+++ b/zio-k8s-crd/src/main/scala/com/coralogix/zio/k8s/crd/guardrail/K8sCodegenContext.scala
@@ -5,5 +5,6 @@ case class K8sCodegenContext(
   group: String,
   version: String,
   plural: String,
-  hasStatus: Boolean
+  hasStatus: Boolean,
+  isMetadataOptional: Boolean
 )

--- a/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/.scalafmt.conf
+++ b/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/.scalafmt.conf
@@ -1,0 +1,40 @@
+version = "2.7.5"
+maxColumn = 100
+
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+
+spaces {
+  inImportCurlyBraces = true
+}
+
+align {
+  arrowEnumeratorGenerator = true
+  openParenCallSite = false
+
+  tokens = [
+    { code = "<-", owner = "Enumerator.Generator" }
+    { code = "=", owner = "(Enumerator.Val|Term.Arg.Named)" }
+    { code = "%", owner = "Term.ApplyInfix" }
+    { code = "%%", owner = "Term.ApplyInfix" }
+    { code = "=>", owner = "Case" }
+    { code = "->", owner = "Term.Apply" }
+    { code = ":=", owner = "Term.Apply" }
+  ]
+}
+
+binPack {
+  parentConstructors = true
+}
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = true
+}
+
+assumeStandardLibraryStripMargin = true
+
+rewrite.rules = [RedundantBraces, PreferCurlyFors, SortImports]
+
+lineEndings = preserve

--- a/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/build.sbt
+++ b/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/build.sbt
@@ -1,0 +1,9 @@
+externalCustomResourceDefinitions := Seq(
+  file("crds/helmrelease.yaml"),
+)
+
+enablePlugins(K8sCustomResourceCodegenPlugin)
+
+val pluginVersion = System.getProperty("plugin.version")
+libraryDependencies +=
+  "com.coralogix" %% "zio-k8s-client" % pluginVersion

--- a/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/crds/helmrelease.yaml
+++ b/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/crds/helmrelease.yaml
@@ -1,0 +1,445 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+  creationTimestamp: "2021-03-06T12:09:50Z"
+  generation: 1
+  name: helmreleases.helm.fluxcd.io
+  resourceVersion: "955944"
+  selfLink: /apis/apiextensions.k8s.io/v1/customresourcedefinitions/helmreleases.helm.fluxcd.io
+  uid: 10d8541b-673c-4027-9958-90dc77cb4082
+spec:
+  conversion:
+    strategy: None
+  group: helm.fluxcd.io
+  names:
+    kind: HelmRelease
+    listKind: HelmReleaseList
+    plural: helmreleases
+    shortNames:
+      - hr
+      - hrs
+    singular: helmrelease
+  preserveUnknownFields: true
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: ReleaseName is the name of the Helm release managed by the HelmRelease,
+            as given by Helm.
+          jsonPath: .status.releaseName
+          name: Release
+          type: string
+        - description: Phase is the current release phase being performed for the HelmRelease.
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: ReleaseStatus is the status of the Helm release managed by the
+            HelmRelease, as given by Helm.
+          jsonPath: .status.releaseStatus
+          name: Status
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Released")].message
+          name: Message
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before
+            order across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: HelmRelease is a type to represent a Helm release.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                chart:
+                  properties:
+                    chartPullSecret:
+                      description: ChartPullSecret holds the reference to the authentication
+                        secret for accessing the Helm repository using HTTPS basic auth.
+                        NOT IMPLEMENTED!
+                      properties:
+                        name:
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    git:
+                      description: Git URL is the URL of the Git repository, e.g. `git@github.com:org/repo`,
+                        `http://github.com/org/repo`, or `ssh://git@example.com:2222/org/repo.git`.
+                      type: string
+                    name:
+                      description: Name is the name of the Helm chart _without_ an alias,
+                        e.g. redis (for `helm upgrade [flags] stable/redis`).
+                      type: string
+                    path:
+                      description: Path is the path to the chart relative to the repository
+                        root.
+                      type: string
+                    ref:
+                      description: Ref is the Git branch (or other reference) to use.
+                        Defaults to 'master', or the configured default Git ref.
+                      type: string
+                    repository:
+                      description: RepoURL is the URL of the Helm repository, e.g. `https://kubernetes-charts.storage.googleapis.com`
+                        or `https://charts.example.com`.
+                      type: string
+                    secretRef:
+                      description: SecretRef holds the authentication secret for accessing
+                        the Git repository (over HTTPS). The credentials will be added
+                        to an HTTPS GitURL before the mirror is started.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    skipDepUpdate:
+                      description: SkipDepUpdate will tell the operator to skip running
+                        'helm dep update' before installing or upgrading the chart,
+                        the chart dependencies _must_ be present for this to succeed.
+                      type: boolean
+                    version:
+                      description: Version is the targeted Helm chart version, e.g.
+                        7.0.1.
+                      type: string
+                  type: object
+                disableOpenAPIValidation:
+                  description: DisableOpenAPIValidation controls whether OpenAPI validation
+                    is enforced.
+                  type: boolean
+                forceUpgrade:
+                  description: Force will mark this Helm release to `--force` upgrades.
+                    This forces the resource updates through delete/recreate if needed.
+                  type: boolean
+                helmVersion:
+                  description: 'HelmVersion is the version of Helm to target. If not
+                  supplied, the lowest _enabled Helm version_ will be targeted. Valid
+                  HelmVersion values are: "v2", "v3"'
+                  enum:
+                    - v2
+                    - v3
+                  type: string
+                maxHistory:
+                  description: MaxHistory is the maximum amount of revisions to keep
+                    for the Helm release. If not supplied, it defaults to 10.
+                  type: integer
+                releaseName:
+                  description: ReleaseName is the name of the The Helm release. If not
+                    supplied, it will be generated by affixing the namespace to the
+                    resource name.
+                  type: string
+                resetValues:
+                  description: ResetValues will mark this Helm release to reset the
+                    values to the defaults of the targeted chart before performing an
+                    upgrade. Not explicitly setting this to `false` equals to `true`
+                    due to the declarative nature of the operator.
+                  type: boolean
+                rollback:
+                  description: The rollback settings for this Helm release.
+                  properties:
+                    disableHooks:
+                      description: DisableHooks will mark this Helm release to prevent
+                        hooks from running during the rollback.
+                      type: boolean
+                    enable:
+                      description: Enable will mark this Helm release for rollbacks.
+                      type: boolean
+                    force:
+                      description: Force will mark this Helm release to `--force` rollbacks.
+                        This forces the resource updates through delete/recreate if
+                        needed.
+                      type: boolean
+                    maxRetries:
+                      description: MaxRetries is the maximum amount of upgrade retries
+                        the operator should make before bailing.
+                      format: int64
+                      type: integer
+                    recreate:
+                      description: Recreate will mark this Helm release to `--recreate-pods`
+                        for if applicable. This performs pod restarts.
+                      type: boolean
+                    retry:
+                      description: Retry will mark this Helm release for upgrade retries
+                        after a rollback.
+                      type: boolean
+                    timeout:
+                      description: Timeout is the time to wait for any individual Kubernetes
+                        operation (like Jobs for hooks) during rollback.
+                      format: int64
+                      type: integer
+                    wait:
+                      description: Wait will mark this Helm release to wait until all
+                        Pods, PVCs, Services, and minimum number of Pods of a Deployment,
+                        StatefulSet, or ReplicaSet are in a ready state before marking
+                        the release as successful.
+                      type: boolean
+                  type: object
+                skipCRDs:
+                  description: SkipCRDs will mark this Helm release to skip the creation
+                    of CRDs during a Helm 3 installation.
+                  type: boolean
+                targetNamespace:
+                  description: TargetNamespace overrides the targeted namespace for
+                    the Helm release. The default namespace equals to the namespace
+                    of the HelmRelease resource.
+                  type: string
+                test:
+                  description: The test settings for this Helm release.
+                  properties:
+                    cleanup:
+                      description: Cleanup, when targeting Helm 2, determines whether
+                        to delete test pods between each test run initiated by the Helm
+                        Operator.
+                      type: boolean
+                    enable:
+                      description: Enable will mark this Helm release for tests.
+                      type: boolean
+                    ignoreFailures:
+                      description: IgnoreFailures will cause a Helm release to be rolled
+                        back if it fails otherwise it will be left in a released state
+                      type: boolean
+                    timeout:
+                      description: Timeout is the time to wait for any individual Kubernetes
+                        operation (like Jobs for hooks) during test.
+                      format: int64
+                      type: integer
+                  type: object
+                timeout:
+                  description: Timeout is the time to wait for any individual Kubernetes
+                    operation (like Jobs for hooks) during installation and upgrade
+                    operations.
+                  format: int64
+                  type: integer
+                valueFileSecrets:
+                  description: ValueFileSecrets holds the local name references to secrets.
+                    DEPRECATED, use ValuesFrom.secretKeyRef instead.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                values:
+                  description: Values holds the values for this Helm release.
+                  type: object
+                valuesFrom:
+                  items:
+                    properties:
+                      chartFileRef:
+                        description: The reference to a local chart file with release
+                          values.
+                        properties:
+                          optional:
+                            description: Optional will mark this ChartFileSelector as
+                              optional. The result of this are that operations are permitted
+                              without the source, due to it e.g. being temporarily unavailable.
+                            type: boolean
+                          path:
+                            description: Path is the file path to the source relative
+                              to the chart root.
+                            type: string
+                        required:
+                          - path
+                        type: object
+                      configMapKeyRef:
+                        description: The reference to a config map with release values.
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          optional:
+                            type: boolean
+                        required:
+                          - name
+                        type: object
+                      externalSourceRef:
+                        description: The reference to an external source with release
+                          values.
+                        properties:
+                          optional:
+                            description: Optional will mark this ExternalSourceSelector
+                              as optional. The result of this are that operations are
+                              permitted without the source, due to it e.g. being temporarily
+                              unavailable.
+                            type: boolean
+                          url:
+                            description: URL is the URL of the external source.
+                            type: string
+                        required:
+                          - url
+                        type: object
+                      secretKeyRef:
+                        description: The reference to a secret with release values.
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          optional:
+                            type: boolean
+                        required:
+                          - name
+                        type: object
+                    type: object
+                  type: array
+                wait:
+                  description: Wait will mark this Helm release to wait until all Pods,
+                    PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet,
+                    or ReplicaSet are in a ready state before marking the release as
+                    successful.
+                  type: boolean
+              required:
+                - chart
+              type: object
+            status:
+              description: HelmReleaseStatus contains status information about an HelmRelease.
+              properties:
+                conditions:
+                  description: Conditions contains observations of the resource's state,
+                    e.g., has the chart which it refers to been fetched.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        format: date-time
+                        type: string
+                      lastUpdateTime:
+                        description: LastUpdateTime is the timestamp corresponding to
+                          the last status update of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human readable description of the
+                          details of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of the condition, one of ('ChartFetched',
+                          'Deployed', 'Released', 'RolledBack', 'Tested').
+                        enum:
+                          - ChartFetched
+                          - Deployed
+                          - Released
+                          - RolledBack
+                          - Tested
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastAttemptedRevision:
+                  description: LastAttemptedRevision is the revision of the latest chart
+                    sync, and may be of a failed release.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed
+                    by the operator.
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase the release is in, one of ('ChartFetched', 'ChartFetchFailed',
+                    'Installing', 'Upgrading', 'Deployed', 'DeployFailed', 'Testing',
+                    'TestFailed', 'Tested', 'Succeeded', 'RollingBack', 'RolledBack',
+                    'RollbackFailed')
+                  enum:
+                    - ChartFetched
+                    - ChartFetchFailed
+                    - Installing
+                    - Upgrading
+                    - Deployed
+                    - DeployFailed
+                    - Testing
+                    - TestFailed
+                    - Tested
+                    - Succeeded
+                    - Failed
+                    - RollingBack
+                    - RolledBack
+                    - RollbackFailed
+                  type: string
+                releaseName:
+                  description: ReleaseName is the name as either supplied or generated.
+                  type: string
+                releaseStatus:
+                  description: ReleaseStatus is the status as given by Helm for the
+                    release managed by this resource.
+                  type: string
+                revision:
+                  description: Revision holds the Git hash or version of the chart currently
+                    deployed.
+                  type: string
+                rollbackCount:
+                  description: RollbackCount records the amount of rollback attempts
+                    made, it is incremented after a rollback failure and reset after
+                    a successful upgrade or revision change.
+                  format: int64
+                  type: integer
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: HelmRelease
+    listKind: HelmReleaseList
+    plural: helmreleases
+    shortNames:
+      - hr
+      - hrs
+    singular: helmrelease
+  conditions:
+    - lastTransitionTime: "2021-03-06T12:09:50Z"
+      message: no conflicts found
+      reason: NoConflicts
+      status: "True"
+      type: NamesAccepted
+    - lastTransitionTime: "2021-03-06T12:09:51Z"
+      message: the initial names have been accepted
+      reason: InitialNamesAccepted
+      status: "True"
+      type: Established
+  storedVersions:
+    - v1

--- a/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/project/plugins.sbt
+++ b/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.coralogix" % "zio-k8s-crd" % pluginVersion)
+}

--- a/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/src/main/scala/Test.scala
+++ b/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/src/main/scala/Test.scala
@@ -1,0 +1,14 @@
+import com.coralogix.zio.k8s.client.io.fluxcd.helm.definitions.helmrelease.v1._
+import com.coralogix.zio.k8s.model.pkg.apis.meta.v1.ObjectMeta
+
+object Test {
+  val test = HelmRelease(
+    metadata = ObjectMeta(name = "test"),
+    spec = HelmRelease.Spec(
+      chart = HelmRelease.Spec.Chart(),
+      rollback = HelmRelease.Spec.Rollback(
+        wait_ = true
+      )
+    )
+  )
+}

--- a/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/test
+++ b/zio-k8s-crd/src/sbt-test/zio-k8s-crd/crd-test-3/test
@@ -1,0 +1,2 @@
+> clean
+> compile


### PR DESCRIPTION
Fixes some issues with the CRD support reported in #129:

- Always use the proper type for the top level `metadata` field
- Handle non-optional `metadata field
- Rename fields with names colliding with Java `Object`'s methods