### PR TITLE
support token generation through command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val client = Project("zio-k8s-client", file("zio-k8s-client"))
       "dev.zio"                       %% "zio-config"                    % zioConfigVersion,
       "dev.zio"                       %% "zio-logging"                   % "0.5.11",
       "dev.zio"                       %% "zio-nio"                       % "1.0.0-RC11",
+      "dev.zio"                       %% "zio-process"                   % "0.5.0",
       "com.softwaremill.sttp.client3" %% "core"                          % sttpVersion,
       "com.softwaremill.sttp.client3" %% "zio"                           % sttpVersion,
       "com.softwaremill.sttp.client3" %% "circe"                         % sttpVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ lazy val client = Project("zio-k8s-client", file("zio-k8s-client"))
       "dev.zio"                       %% "zio-config"                    % zioConfigVersion,
       "dev.zio"                       %% "zio-logging"                   % "0.5.11",
       "dev.zio"                       %% "zio-nio"                       % "1.0.0-RC11",
-      "dev.zio"                       %% "zio-process"                   % "0.5.0",
+      "dev.zio"                       %% "zio-process"                   % "0.5.0" exclude ("org.scala-lang.modules", "scala-collection-compat_3"),
       "com.softwaremill.sttp.client3" %% "core"                          % sttpVersion,
       "com.softwaremill.sttp.client3" %% "zio"                           % sttpVersion,
       "com.softwaremill.sttp.client3" %% "circe"                         % sttpVersion,

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/Kubeconfig.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/Kubeconfig.scala
@@ -38,6 +38,25 @@ object KubeconfigContext {
   implicit val codec: Codec[KubeconfigContext] = deriveCodec
 }
 
+final case class ExecEnv(name: String, value: String)
+
+object ExecEnv {
+  implicit val codec: Codec[ExecEnv] = deriveCodec
+}
+
+final case class ExecConfig(
+  apiVersion: String,
+  command: String,
+  env: Option[Set[ExecEnv]],
+  args: Option[List[String]],
+  installHint: Option[String],
+  provideClusterInfo: Option[Boolean]
+)
+
+object ExecConfig {
+  implicit val codec: Codec[ExecConfig] = deriveCodec
+}
+
 case class KubeconfigUserInfo(
   `client-certificate`: Option[String],
   `client-certificate-data`: Option[String],
@@ -45,7 +64,8 @@ case class KubeconfigUserInfo(
   `client-key-data`: Option[String],
   token: Option[String],
   username: Option[String],
-  password: Option[String]
+  password: Option[String],
+  exec: Option[ExecConfig]
 )
 
 object KubeconfigUserInfo {

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
@@ -130,7 +130,7 @@ object ConfigSpec extends DefaultRunnableSpec {
             maybeToken  <- loadTokenByCommand.provideLayer(configLayer)
           } yield maybeToken)(Assertion.equalTo(Some("my-bearer-token")))
         )
-      } @@ ignore
+      }
     )
 
   case class Config(k8s: K8sClusterConfig)

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
@@ -1,16 +1,25 @@
 package com.coralogix.zio.k8s.client.config
 
+import io.circe.yaml.parser.parse
 import sttp.client3._
+import zio.{ Chunk, Has, ZIO }
 import zio.config._
 import zio.config.typesafe.TypesafeConfig
 import zio.nio.core.file.Path
 import zio.test.environment.TestEnvironment
 import zio.test.{ assertM, Assertion, DefaultRunnableSpec, ZSpec }
+import cats.implicits._
+import com.coralogix.zio.k8s.client.config.K8sAuthentication.ServiceAccountToken
+import com.coralogix.zio.k8s.client.config.KeySource.FromString
+import zio.nio.file.Files
+import zio.test.TestAspect.ignore
+
+import java.nio.charset.StandardCharsets
 
 object ConfigSpec extends DefaultRunnableSpec {
   override def spec: ZSpec[TestEnvironment, Any] =
     suite("K8sClusterConfig descriptors")(
-      testM("example1") {
+      testM("load client config") {
         // Loading config from HOCON
         val loadConfig =
           TypesafeConfig.fromHoconString[Config](example1, configDesc).build.useNow.map(_.get)
@@ -37,7 +46,91 @@ object ConfigSpec extends DefaultRunnableSpec {
             )
           )
         )
-      }
+      },
+      testM("parse kube config") {
+        val kubeConfig = parseKubeConfigYaml(example2)
+
+        assertM(kubeConfig)(
+          Assertion.equalTo(
+            Kubeconfig(
+              clusters = List(
+                KubeconfigCluster(
+                  "test_cluster",
+                  KubeconfigClusterInfo(
+                    "https://127.0.0.1:696",
+                    None,
+                    "DDDDAAAANNNNYYYYMMMMOOOORRRR".some
+                  )
+                )
+              ),
+              contexts = List(
+                KubeconfigContext(
+                  name = "test",
+                  context =
+                    KubeconfigContextInfo("test_cluster", "test_user", "test_namespace".some)
+                )
+              ),
+              users = List(
+                KubeconfigUser(
+                  "test_user",
+                  KubeconfigUserInfo(
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    ExecConfig(
+                      apiVersion = "client.authentication.k8s.io/v1alpha1",
+                      command = "echo",
+                      env = Set(ExecEnv("BEARER_TOKEN", "bearer-token")).some,
+                      args = List(
+                        "{ \"apiVersion\": \"client.authentication.k8s.io/v1alpha1\", \"kind\": \"ExecCredential\", \"status\": {\"token\": \"bearer-token\" }}"
+                      ).some,
+                      None,
+                      None
+                    ).some
+                  )
+                )
+              ),
+              `current-context` = "test"
+            )
+          )
+        )
+      },
+      testM("run local config loading") {
+        def createTempKubeConfigFile =
+          for {
+            path <- Files
+                      .createTempFileManaged(prefix = "zio_k8s_test_".some)
+            _    <- Files
+                      .writeBytes(
+                        path,
+                        Chunk.fromArray(example2.getBytes(StandardCharsets.UTF_8))
+                      )
+                      .toManaged_
+          } yield path
+
+        def loadTokenByCommand: ZIO[Has[K8sClusterConfig], Throwable, Option[String]] =
+          for {
+            authentication <-
+              ZIO.access[Has[K8sClusterConfig]](_.get[K8sClusterConfig].authentication)
+            result         <- authentication match {
+                                case ServiceAccountToken(FromString(token)) =>
+                                  ZIO.succeed(token.some)
+                                case _                                      =>
+                                  ZIO.none
+                              }
+          } yield result
+
+        createTempKubeConfigFile.use(path =>
+          assertM(for {
+            configLayer <- ZIO.effect(kubeconfigFile(path))
+            maybeToken  <- loadTokenByCommand.provideLayer(configLayer)
+          } yield maybeToken)(Assertion.equalTo(Some("my-bearer-token")))
+        )
+      } @@ ignore
     )
 
   case class Config(k8s: K8sClusterConfig)
@@ -63,4 +156,39 @@ object ConfigSpec extends DefaultRunnableSpec {
       |    }
       |  }
       |}""".stripMargin
+
+  def parseKubeConfigYaml(yamlString: String) =
+    for {
+      yaml       <- ZIO.fromEither(parse(yamlString))
+      kubeconfig <- ZIO.fromEither(yaml.as[Kubeconfig])
+    } yield kubeconfig
+
+  val example2: String =
+    """apiVersion: v1
+      |clusters:
+      |- cluster:
+      |    certificate-authority-data: DDDDAAAANNNNYYYYMMMMOOOORRRR
+      |    server: https://127.0.0.1:696
+      |  name: test_cluster
+      |contexts:
+      |- context:
+      |    cluster: test_cluster
+      |    namespace: test_namespace
+      |    user: test_user
+      |  name: test
+      |current-context: test
+      |kind: Config
+      |preferences: {}
+      |users:
+      |- name: test_user
+      |  user:
+      |    exec:
+      |      apiVersion: client.authentication.k8s.io/v1alpha1
+      |      args:
+      |      - "{ \"apiVersion\": \"client.authentication.k8s.io/v1alpha1\", \"kind\": \"ExecCredential\", \"status\": {\"token\": \"bearer-token\" }}"
+      |      command: echo 
+      |      env:
+      |      - name: BEARER_TOKEN
+      |        value: bearer-token
+      |""".stripMargin
 }

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
@@ -12,7 +12,6 @@ import cats.implicits._
 import com.coralogix.zio.k8s.client.config.K8sAuthentication.ServiceAccountToken
 import com.coralogix.zio.k8s.client.config.KeySource.FromString
 import zio.nio.file.Files
-import zio.test.TestAspect.ignore
 
 import java.nio.charset.StandardCharsets
 

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
@@ -127,7 +127,7 @@ object ConfigSpec extends DefaultRunnableSpec {
           assertM(for {
             configLayer <- ZIO.effect(kubeconfigFile(path))
             maybeToken  <- loadTokenByCommand.provideLayer(configLayer)
-          } yield maybeToken)(Assertion.equalTo(Some("my-bearer-token")))
+          } yield maybeToken)(Assertion.equalTo(Some("bearer-token")))
         )
       }
     )


### PR DESCRIPTION
Add support for token generation through external command.
there's an option in the kube config to specify a command with which you can exchange credentials with an external service for a token. the token is then used by the client for authentication.
An example would be issuing a token to an EKS cluster:

```
- name: some_eks_arn:cluster/k8s
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      args:
      - --region
      - us-west-2
      - eks
      - get-token
      - --cluster-name
      - k8s
      command: aws
      env:
      - name: AWS_PROFILE
        value: some_profile
```

The main guidance to the implementation was the following doc:
https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins 