### PR TITLE
Fix API compatibility for softwaremill quicklens 1.8.7+ for scala3

### DIFF
--- a/zio-k8s-client-quicklens/src/main/scala-3/com/coralogix/zio/k8s/quicklens/package.scala
+++ b/zio-k8s-client-quicklens/src/main/scala-3/com/coralogix/zio/k8s/quicklens/package.scala
@@ -21,6 +21,6 @@ package object quicklens {
   }
 
   given QuicklensFunctor[Optional] with {
-    def map[A, B](fa: Optional[A], f: A => B): Optional[B] = fa.map(f)
+    def map[A](fa: Optional[A], f: A => A): Optional[A] = fa.map(f)
   }
 }

--- a/zio-k8s-client-quicklens/src/test/scala/com/coralogix/zio/k8s/quicklens/QuicklensOptionalSpec.scala
+++ b/zio-k8s-client-quicklens/src/test/scala/com/coralogix/zio/k8s/quicklens/QuicklensOptionalSpec.scala
@@ -1,6 +1,7 @@
 package com.coralogix.zio.k8s.quicklens
 
 import com.coralogix.zio.k8s.client.model.Optional
+import com.coralogix.zio.k8s.client.model.Optional._
 import com.softwaremill.quicklens._
 import zio.test.environment.TestEnvironment
 import zio.test.Assertion._
@@ -15,7 +16,7 @@ object QuicklensOptionalSpec extends DefaultRunnableSpec {
     suite("Quicklens support")(
       test("works on optionals") {
         val a = X(Y(None))
-        val f = modify(_: X)(_.inner.each.leaf).setTo(5)
+        val f = modify[X, Optional[Int]](_: X)(_.inner.each.leaf).setTo(5)
         val g = modify(_: X)(_.inner.each.leaf.each)(_ + 1)
         val b = g(f(a))
 


### PR DESCRIPTION
In test, compiler unable to apply implicit conversion without explicit value type definition.
So we either need to provide `Optional[Int]` value explicitly to function or define type in parameters. (Applicable only for scala 3)