### PR TITLE
Fix issue related to SSL inputStream

### DIFF
--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/SSL.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/SSL.scala
@@ -1,10 +1,10 @@
 package com.coralogix.zio.k8s.client.config
 
-import zio.{Task, ZIO}
+import zio.{ Task, ZIO }
 
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
-import javax.net.ssl.{KeyManager, SSLContext, TrustManager, X509TrustManager}
+import javax.net.ssl.{ KeyManager, SSLContext, TrustManager, X509TrustManager }
 
 object SSL {
   def apply(

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/SSL.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/SSL.scala
@@ -1,10 +1,10 @@
 package com.coralogix.zio.k8s.client.config
 
-import zio.{ System, Task, ZIO }
+import zio.{Task, ZIO}
 
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
-import javax.net.ssl.{ KeyManager, SSLContext, TrustManager, X509TrustManager }
+import javax.net.ssl.{KeyManager, SSLContext, TrustManager, X509TrustManager}
 
 object SSL {
   def apply(

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
@@ -3,15 +3,15 @@ package com.coralogix.zio.k8s.client
 import cats.implicits._
 import com.coralogix.zio.k8s.client.model.K8sCluster
 import io.circe.generic.semiauto.deriveDecoder
-import io.circe.{Decoder, parser}
+import io.circe.{ parser, Decoder }
 import sttp.client3.UriContext
 import sttp.model.Uri
 import zio.config._
 import zio.nio.file.Path
 import zio.process.Command
-import zio.{Layer, RIO, Scope, System, Task, ZIO, ZLayer}
+import zio.{ Layer, RIO, Scope, System, Task, ZIO, ZLayer }
 
-import java.io.{ByteArrayInputStream, File, FileInputStream, InputStream}
+import java.io.{ ByteArrayInputStream, File, FileInputStream, InputStream }
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
@@ -3,15 +3,15 @@ package com.coralogix.zio.k8s.client
 import cats.implicits._
 import com.coralogix.zio.k8s.client.model.K8sCluster
 import io.circe.generic.semiauto.deriveDecoder
-import io.circe.{ parser, Decoder }
+import io.circe.{Decoder, parser}
 import sttp.client3.UriContext
 import sttp.model.Uri
 import zio.config._
 import zio.nio.file.Path
 import zio.process.Command
-import zio.{ Layer, RIO, System, Task, ZIO, ZLayer }
+import zio.{Layer, RIO, Scope, Task, ZIO, ZLayer}
 
-import java.io.{ ByteArrayInputStream, File, FileInputStream, InputStream }
+import java.io.{ByteArrayInputStream, File, FileInputStream, InputStream}
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
@@ -557,17 +557,15 @@ package object config extends Descriptors {
     } yield auth
   }
 
-  private[config] def loadKeyStream(source: KeySource): ZIO[Any, Throwable, InputStream] =
-    ZIO.scoped {
-      ZIO.fromAutoCloseable {
-        source match {
-          case KeySource.FromFile(path)     =>
-            ZIO.attempt(new FileInputStream(path.toFile))
-          case KeySource.FromBase64(base64) =>
-            ZIO.attempt(new ByteArrayInputStream(Base64.getDecoder.decode(base64)))
-          case KeySource.FromString(value)  =>
-            ZIO.attempt(new ByteArrayInputStream(value.getBytes(StandardCharsets.US_ASCII)))
-        }
+  private[config] def loadKeyStream(source: KeySource): ZIO[Scope, Throwable, InputStream] =
+    ZIO.fromAutoCloseable {
+      source match {
+        case KeySource.FromFile(path)     =>
+          ZIO.attempt(new FileInputStream(path.toFile))
+        case KeySource.FromBase64(base64) =>
+          ZIO.attempt(new ByteArrayInputStream(Base64.getDecoder.decode(base64)))
+        case KeySource.FromString(value)  =>
+          ZIO.attempt(new ByteArrayInputStream(value.getBytes(StandardCharsets.US_ASCII)))
       }
     }
 

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
@@ -9,7 +9,7 @@ import sttp.model.Uri
 import zio.config._
 import zio.nio.file.Path
 import zio.process.Command
-import zio.{Layer, RIO, Scope, Task, ZIO, ZLayer}
+import zio.{Layer, RIO, Scope, System, Task, ZIO, ZLayer}
 
 import java.io.{ByteArrayInputStream, File, FileInputStream, InputStream}
 import java.nio.charset.StandardCharsets


### PR DESCRIPTION
InputStream is getting closed as the scope usage is not proper.
```Exception in thread "zio-fiber-10,21,16,11,8" java.io.IOException: java.io.IOException: Stream Closed
	at com.coralogix.zio.k8s.client.config.TrustManagers.createTrustStore(TrustManagers.scala:63)
	at com.coralogix.zio.k8s.client.config.TrustManagers.apply(TrustManagers.scala:77)
	at com.coralogix.zio.k8s.client.config.SSL.secureSSLContext(SSL.scala:47)
	at com.coralogix.zio.k8s.client.config.SSL.secureSSLContext(SSL.scala:38)
	at com.coralogix.zio.k8s.client.config.httpclient.package.k8sSttpClient(package.scala:35)
	at com.coralogix.zio.k8s.client.config.httpclient.package.k8sSttpClient(package.scala:22)```