### PR TITLE
Update Scala, ZIO, STTP, SBT and quicklens dependencies to avoid "Defect in zio.ZEnvironment" error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: coursier/cache-action@v5
       - name: Build and test
         run: |
-          sbt ++2.12.15 clean scalafmtCheckAll test zio-k8s-crd/scripted docs/mdoc
+          sbt ++2.12.17 clean scalafmtCheckAll test zio-k8s-crd/scripted docs/mdoc
 
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
@@ -37,7 +37,7 @@ jobs:
         uses: coursier/cache-action@v5
       - name: Build and test
         run: |
-          sbt ++2.13.6 clean scalafmtCheckAll zio-k8s-client/test zio-k8s-operator/test examples/compile
+          sbt ++2.13.10 clean scalafmtCheckAll zio-k8s-client/test zio-k8s-operator/test examples/compile
       
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
@@ -58,7 +58,7 @@ jobs:
         uses: coursier/cache-action@v5
       - name: Build and test
         run: |
-          sbt ++3.1.0 clean zio-k8s-client/test zio-k8s-operator/test leader-example/compile logs-example/compile
+          sbt ++3.2.2 clean zio-k8s-client/test zio-k8s-operator/test leader-example/compile logs-example/compile
 
           rm -rf "$HOME/.ivy2/local" || true
           find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
-val scala212Version = "2.12.16"
-val scala213Version = "2.13.8"
-val scala3Version = "3.1.3"
+val scala212Version = "2.12.17"
+val scala213Version = "2.13.10"
+val scala3Version = "3.2.2"
 
-val zioVersion = "2.0.0"
-val zioConfigVersion = "3.0.1"
-val zioLoggingVersion = "2.0.0"
-val sttpVersion = "3.7.0"
-val zioNioVersion = "2.0.0"
-val zioPreludeVersion = "1.0.0-RC15"
+val zioVersion = "2.0.9"
+val zioConfigVersion = "3.0.7"
+val zioLoggingVersion = "2.1.7"
+val sttpVersion = "3.8.1"
+val zioNioVersion = "2.0.1"
+val zioPreludeVersion = "1.0.0-RC16"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -102,7 +102,7 @@ lazy val clientQuicklens = Project("zio-k8s-client-quicklens", file("zio-k8s-cli
   .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.softwaremill.quicklens" %% "quicklens"    % "1.8.8",
+      "com.softwaremill.quicklens" %% "quicklens"    % "1.8.10",
       "dev.zio"                    %% "zio-test"     % zioVersion % Test,
       "dev.zio"                    %% "zio-test-sbt" % zioVersion % Test
     ),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.2
+sbt.version = 1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"        % "2.4.6")
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"      % "1.5.10")
-addSbtPlugin("com.github.sbt"                    % "sbt-native-packager" % "1.9.9")
+addSbtPlugin("com.github.sbt"                    % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"            % "2.3.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-unidoc"          % "0.5.0")
 addSbtPlugin("com.eed3si9n"                      % "sbt-buildinfo"       % "0.11.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"    % "3.0.2")
-addSbtPlugin("ch.epfl.scala"                      % "sbt-scalafix"       % "0.9.34")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"        % "0.9.34")
 
 libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.11.1"
 

--- a/zio-k8s-codegen/build.sbt
+++ b/zio-k8s-codegen/build.sbt
@@ -3,15 +3,15 @@ sbtPlugin := true
 organization := "com.coralogix"
 name         := "zio-k8s-codegen"
 
-scalaVersion := "2.12.16"
+scalaVersion := "2.12.17"
 
 Compile / unmanagedSourceDirectories += baseDirectory.value / "src/shared/scala"
 
 scalacOptions ++= Seq("-feature", "-deprecation")
 
 libraryDependencies ++= Seq(
-  "dev.zio"             %% "zio"              % "2.0.0",
-  "dev.zio"             %% "zio-nio"          % "2.0.0",
+  "dev.zio"             %% "zio"              % "2.0.9",
+  "dev.zio"             %% "zio-nio"          % "2.0.1",
   "io.swagger.parser.v3" % "swagger-parser"   % "2.0.24",
   "io.circe"            %% "circe-core"       % "0.14.2",
   "io.circe"            %% "circe-parser"     % "0.14.2",


### PR DESCRIPTION
When creating a new project with the latest Scala (version 3.2.2) and ZIO (version 2.0.9) versions, running the application fails with the error message: "java.lang.Error: Defect in zio.ZEnvironment: Set(package::K8sCluster) statically known to be contained within the environment are missing."

To resolve this issue, I upgraded the Scala and ZIO dependencies to the latest versions (and other dependencies, too, while I was at it).