### PR TITLE
Add resourceVersion tracking to watchforever

### DIFF
--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/Resource.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/Resource.scala
@@ -82,6 +82,8 @@ trait Resource[T] {
     * @param namespace
     *   Constraint the watched resources by their namespace. If None, all namespaces will be
     *   watched.
+    * @param resourceVersion
+    *   Last known resource version to start watch from.
     * @param fieldSelector
     *   Constrain the returned items by field selectors. Not all fields are supported by the server.
     * @param labelSelector
@@ -91,10 +93,11 @@ trait Resource[T] {
     */
   def watchForever(
     namespace: Option[K8sNamespace],
+    resourceVersion: Option[String] = None,
     fieldSelector: Option[FieldSelector] = None,
     labelSelector: Option[LabelSelector] = None
   ): ZStream[Any, K8sFailure, TypedWatchEvent[T]] =
-    ZStream.succeed(Reseted[T]()) ++ watch(namespace, None, fieldSelector, labelSelector)
+    ZStream.succeed(Reseted[T]()) ++ watch(namespace, resourceVersion, fieldSelector, labelSelector)
       .retry(Schedule.recurWhileEquals(Gone))
 
   /** Get a resource by its name
@@ -224,10 +227,11 @@ trait NamespacedResource[T] {
     */
   def watchForever(
     namespace: Option[K8sNamespace],
+    resourceVersion: Option[String] = None,
     fieldSelector: Option[FieldSelector] = None,
     labelSelector: Option[LabelSelector] = None
   ): ZStream[Any, K8sFailure, TypedWatchEvent[T]] =
-    asGenericResource.watchForever(namespace, fieldSelector, labelSelector)
+    asGenericResource.watchForever(namespace, resourceVersion, fieldSelector, labelSelector)
 
   /** Get a resource by its name
     * @param name
@@ -344,10 +348,11 @@ trait ClusterResource[T] {
     *   A stream of watch events
     */
   def watchForever(
+    resourceVersion: Option[String] = None,
     fieldSelector: Option[FieldSelector] = None,
     labelSelector: Option[LabelSelector] = None
   ): ZStream[Any, K8sFailure, TypedWatchEvent[T]] =
-    asGenericResource.watchForever(None, fieldSelector, labelSelector)
+    asGenericResource.watchForever(None, resourceVersion, fieldSelector, labelSelector)
 
   /** Get a resource by its name
     * @param name

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClient.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClient.scala
@@ -329,6 +329,8 @@ object ResourceClient {
       * @param namespace
       *   Constraint the watched resources by their namespace. If None, all namespaces will be
       *   watched.
+      * @param resourceVersion
+      *   Last known resource version
       * @param fieldSelector
       *   Constrain the returned items by field selectors. Not all fields are supported by the
       *   server.
@@ -339,13 +341,14 @@ object ResourceClient {
       */
     def watchForever[T: EnvironmentTag](
       namespace: Option[K8sNamespace],
+      resourceVersion: Option[String] = None,
       fieldSelector: Option[FieldSelector] = None,
       labelSelector: Option[LabelSelector] = None
     ): ZStream[NamespacedResource[T], K8sFailure, TypedWatchEvent[
       T
     ]] =
       ZStream.environmentWithStream[NamespacedResource[T]](
-        _.get.watchForever(namespace, fieldSelector, labelSelector)
+        _.get.watchForever(namespace, resourceVersion, fieldSelector, labelSelector)
       )
 
     /** Get a resource by its name
@@ -580,6 +583,8 @@ object ResourceClient {
       *
       * The underlying implementation takes advantage of Kubernetes watch bookmarks.
       *
+      * @param resourceVersion
+      *   Last known resource version
       * @param fieldSelector
       *   Constrain the returned items by field selectors. Not all fields are supported by the
       *   server.
@@ -589,11 +594,12 @@ object ResourceClient {
       *   A stream of watch events
       */
     def watchForever[T: EnvironmentTag](
+      resourceVersion: Option[String] = None,
       fieldSelector: Option[FieldSelector] = None,
       labelSelector: Option[LabelSelector] = None
     ): ZStream[ClusterResource[T], K8sFailure, TypedWatchEvent[T]] =
       ZStream.environmentWithStream[ClusterResource[T]](
-        _.get.watchForever(fieldSelector, labelSelector)
+        _.get.watchForever(resourceVersion, fieldSelector, labelSelector)
       )
 
     /** Get a resource by its name

--- a/zio-k8s-codegen/src/shared/scala/com/coralogix/zio/k8s/codegen/internal/ClientModuleGenerator.scala
+++ b/zio-k8s-codegen/src/shared/scala/com/coralogix/zio/k8s/codegen/internal/ClientModuleGenerator.scala
@@ -389,10 +389,11 @@ trait ClientModuleGenerator {
 
             def watchForever(
               namespace: Option[K8sNamespace],
+              resourceVersion: Option[String] = None,
               fieldSelector: Option[FieldSelector] = None,
               labelSelector: Option[LabelSelector] = None,
             ): ZStream[$typeAliasT, K8sFailure, TypedWatchEvent[$entityT]] =
-              ZStream.environmentWithStream[$typeAliasT](_.get.watchForever(namespace, fieldSelector, labelSelector))
+              ZStream.environmentWithStream[$typeAliasT](_.get.watchForever(namespace, resourceVersion, fieldSelector, labelSelector))
 
             def get(
               name: String,
@@ -630,10 +631,11 @@ trait ClientModuleGenerator {
               ZStream.environmentWithStream[$typeAliasT](_.get.watch(resourceVersion, fieldSelector, labelSelector))
 
             def watchForever(
+              resourceVersion: Option[String]= None,
               fieldSelector: Option[FieldSelector] = None,
               labelSelector: Option[LabelSelector] = None,
             ): ZStream[$typeAliasT, K8sFailure, TypedWatchEvent[$entityT]] =
-              ZStream.environmentWithStream[$typeAliasT](_.get.watchForever(fieldSelector, labelSelector))
+              ZStream.environmentWithStream[$typeAliasT](_.get.watchForever(resourceVersion, fieldSelector, labelSelector))
 
             def get(
               name: String,


### PR DESCRIPTION
 closes: [466](https://github.com/coralogix/zio-k8s/issues/466)
Did not add a test case because there is not much business logic change. Please let me know @vigoo if you think this warrants a test case