### PR TITLE
Bump zio 1 circe yaml version to use snakeYaml 2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val client = Project("zio-k8s-client", file("zio-k8s-client"))
       "io.circe"                      %% "circe-core"                    % "0.14.2",
       "io.circe"                      %% "circe-generic"                 % "0.14.2",
       "io.circe"                      %% "circe-parser"                  % "0.14.2",
-      "io.circe"                      %% "circe-yaml"                    % "0.14.1",
+      "io.circe"                      %% "circe-yaml"                    % "0.15.0-RC1",
       "org.bouncycastle"               % "bcpkix-jdk18on"                % "1.71",
       "dev.zio"                       %% "zio-test"                      % zioVersion       % Test,
       "dev.zio"                       %% "zio-test-sbt"                  % zioVersion       % Test,

--- a/zio-k8s-codegen/build.sbt
+++ b/zio-k8s-codegen/build.sbt
@@ -12,10 +12,10 @@ scalacOptions ++= Seq("-feature", "-deprecation")
 libraryDependencies ++= Seq(
   "dev.zio"             %% "zio"              % "1.0.17",
   "dev.zio"             %% "zio-nio"          % "1.0.0-RC12",
-  "io.swagger.parser.v3" % "swagger-parser"   % "2.0.24",
+  "io.swagger.parser.v3" % "swagger-parser"   % "2.1.16",
   "io.circe"            %% "circe-core"       % "0.14.2",
   "io.circe"            %% "circe-parser"     % "0.14.2",
-  "io.circe"            %% "circe-yaml"       % "0.14.1",
+  "io.circe"            %% "circe-yaml"       % "0.15.0-RC1",
   "org.scalameta"       %% "scalameta"        % "4.4.21",
   "org.scalameta"       %% "scalafmt-dynamic" % "2.7.5",
   "org.atteo"            % "evo-inflector"    % "1.3"


### PR DESCRIPTION
Bumps zio 1 branch circe yaml version. This would bump transitive dependency snakeYaml to 2.0. Previous version have security vulnerabilities