### PR TITLE
Fix broken ConfigMapLock and LeaseLock.

### DIFF
--- a/examples/leader-example/src/main/scala/com/coralogix/zio/k8s/examples/leader/LeaderExample.scala
+++ b/examples/leader-example/src/main/scala/com/coralogix/zio/k8s/examples/leader/LeaderExample.scala
@@ -41,7 +41,7 @@ object LeaderExample extends ZIOAppDefault {
   }
 
   private def example(): ZIO[
-    Any with LeaderElection.Service,
+    LeaderElection.Service,
     Nothing,
     Option[Nothing]
   ] =

--- a/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/leader/LeaderLock.scala
+++ b/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/leader/LeaderLock.scala
@@ -2,7 +2,7 @@ package com.coralogix.zio.k8s.operator.leader
 
 import com.coralogix.zio.k8s.client.model.K8sNamespace
 import com.coralogix.zio.k8s.model.core.v1.Pod
-import zio.ZIO
+import zio.{ Scope, ZIO }
 
 /** Common interface for different lock implementations used for leader election.
   */
@@ -10,5 +10,5 @@ trait LeaderLock {
   def acquireLock(
     namespace: K8sNamespace,
     pod: Pod
-  ): ZIO[Any, LeaderElectionFailure[Nothing], Unit]
+  ): ZIO[Scope, LeaderElectionFailure[Nothing], Unit]
 }

--- a/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/leader/locks/LeaseLock.scala
+++ b/zio-k8s-operator/src/main/scala/com/coralogix/zio/k8s/operator/leader/locks/LeaseLock.scala
@@ -29,14 +29,14 @@ class LeaseLock(
   override def acquireLock(
     namespace: K8sNamespace,
     pod: Pod
-  ): ZIO[Any, leader.LeaderElectionFailure[Nothing], Unit] =
-    ZIO.scoped(for {
+  ): ZIO[Scope, leader.LeaderElectionFailure[Nothing], Unit] =
+    for {
       store <- Ref.make(Option.empty[VersionedRecord])
       name  <- pod.getName.mapError(KubernetesError.apply)
       impl   = new Impl(store, namespace, name)
       _     <- ZIO.acquireReleaseInterruptible(impl.acquire())(impl.release())
       _     <- impl.renew().fork
-    } yield ())
+    } yield ()
 
   class Impl(
     store: Ref[Option[VersionedRecord]],

--- a/zio-k8s-operator/src/test/scala/com/coralogix/zio/k8s/operator/leader/locks/ConfigMapLockSpec.scala
+++ b/zio-k8s-operator/src/test/scala/com/coralogix/zio/k8s/operator/leader/locks/ConfigMapLockSpec.scala
@@ -1,0 +1,83 @@
+package com.coralogix.zio.k8s.operator.leader.locks
+
+import com.coralogix.zio.k8s.client.model.K8sNamespace
+import com.coralogix.zio.k8s.client.v1.configmaps.ConfigMaps
+import com.coralogix.zio.k8s.client.v1.pods.Pods
+import com.coralogix.zio.k8s.model.core.v1.Pod
+import com.coralogix.zio.k8s.model.pkg.apis.meta.v1.ObjectMeta
+import com.coralogix.zio.k8s.operator.contextinfo.ContextInfo
+import com.coralogix.zio.k8s.operator.leader
+import com.coralogix.zio.k8s.operator.leader.LeaderElection
+import zio.ZIO.logInfo
+import zio.test.TestAspect.timeout
+import zio.test.{ assertTrue, Spec, TestEnvironment, ZIOSpecDefault }
+import zio.{ durationInt, Promise, Schedule, ZIO, ZLayer }
+
+object ConfigMapLockSpec extends ZIOSpecDefault {
+  private val sharedLayers = ZLayer.make[Pods with ConfigMaps](
+    // The function here is only for deletes and should never be called.
+    Pods.test(() => ???),
+    ConfigMaps.test
+  )
+
+  private def makePod(name: String) =
+    Pod(metadata = Some(ObjectMeta(name = name, uid = Some(name))))
+
+  // Schedule.stop is used so that if acquisition fails, it does not retry.
+  private val leaderElectionLayer = LeaderElection.configMapLock("abc", retryPolicy = Schedule.stop)
+
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("ConfigMap based leader election")(
+      singleLeaderTest,
+      reentranceTest
+    ).provide(sharedLayers) @@ timeout(5.seconds)
+
+  // A ZIO that hogs the lock and never completes. The promise is there to let the caller know that it has started.
+  def lockHogger(promise: Promise[Nothing, Unit]): ZIO[Any, Nothing, Unit] = for {
+    _ <- promise.succeed(())
+    _ <- logInfo("Running locked code")
+    _ <- ZIO.never
+  } yield ()
+
+  val singleLeaderTest: Spec[Pods with ConfigMaps, Any] =
+    test("second fiber should fail to acquire lock") {
+      // We create two ContextInfos so that the two ZIOs trying to get locks can pretend to be different Pods competing
+      // for the same lock.
+      val ciLayer1 = ContextInfo.test(makePod("pod1"), K8sNamespace.default)
+      val ciLayer2 = ContextInfo.test(makePod("pod2"), K8sNamespace.default)
+      for {
+        promise <- Promise.make[Nothing, Unit]
+        fiber   <- leader
+                     .runAsLeader(lockHogger(promise))
+                     .provideSome[ConfigMaps with Pods](ciLayer1, leaderElectionLayer)
+                     .fork
+        // Ensure that fiber has acquired the lock.
+        _       <- promise.await
+        // This will return None since it cannot get the lock.
+        result  <- leader
+                     .runAsLeader(ZIO.unit)
+                     .provideSome[ConfigMaps with Pods](ciLayer2, leaderElectionLayer)
+        _       <- fiber.interrupt
+      } yield assertTrue(result.isEmpty)
+    }
+
+  // The lock should be reentrant.
+  val reentranceTest: Spec[Pods with ConfigMaps, Any] =
+    test("a pod that already has the lock should be able to reuse it") {
+      val ciLayer = ContextInfo.test(makePod("pod1"), K8sNamespace.default)
+      for {
+        promise <- Promise.make[Nothing, Unit]
+        fiber   <- leader
+                     .runAsLeader(lockHogger(promise))
+                     .provideSome[ConfigMaps with Pods](ciLayer, leaderElectionLayer)
+                     .fork
+        // Ensure that fiber1 has acquired the lock.
+        _       <- promise.await
+        // Now reusing the ContextInfo, so it's the same Pod. It already has the lock, so should run successfully.
+        result  <- leader
+                     .runAsLeader(ZIO.unit)
+                     .provideSome[ConfigMaps with Pods](ciLayer, leaderElectionLayer)
+        _       <- fiber.interrupt
+      } yield assertTrue(result.nonEmpty)
+    }
+}


### PR DESCRIPTION
- LeaderForLifeLock#acquireLock must not call ZIO.scoped, or else the scope is closed (and the lock released) at the end of the call, and before the code to be locked gets run. 
- It should not be releasing the lock, since it did not acquire it. Releasing it while another fiber is using it could be dangerous. A full proper implementation would release it only after all users are done, but that is probably a much bigger change.
- LeaseLock#acquireLock should also not call ZIO.scoped.