### PR TITLE
Port token refresh and 401 retry to ZIO 2

### DIFF
--- a/docs/overview/gettingstarted.md
+++ b/docs/overview/gettingstarted.md
@@ -101,7 +101,8 @@ val config = ZLayer.succeed(
         authentication = K8sAuthentication.ServiceAccountToken(
           KeySource.FromFile(
             Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
-          )
+          ),
+          tokenCacheSeconds = 5 // optional, 0 means reload from file for each request
         ),
         K8sClientConfig(
           debug = false,
@@ -157,6 +158,7 @@ k8s {
   authentication {
     serviceAccountToken {
       path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tokenCacheSeconds = 5 # optional, 0 means reload from file for each request
     }
   }
   client {

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/SSL.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/SSL.scala
@@ -39,7 +39,7 @@ object SSL {
       for {
         keyManagers   <-
           authentication match {
-            case K8sAuthentication.ServiceAccountToken(_)                         => ZIO.none
+            case K8sAuthentication.ServiceAccountToken(_, _)                      => ZIO.none
             case K8sAuthentication.BasicAuth(_, _)                                => ZIO.none
             case K8sAuthentication.ClientCertificates(certificate, key, password) =>
               KeyManagers(certificate, key, password).map(Some(_))

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClient.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClient.scala
@@ -51,19 +51,21 @@ final class ResourceClient[
   ): Stream[K8sFailure, T] =
     ZStream.unwrap {
       handleFailures("getAll", namespace, fieldSelector, labelSelector, None) {
-        k8sRequest
-          .get(
-            paginated(
-              namespace,
-              chunkSize,
-              continueToken = None,
-              fieldSelector,
-              labelSelector,
-              resourceVersion
+        k8sRequest.flatMap { request =>
+          request
+            .get(
+              paginated(
+                namespace,
+                chunkSize,
+                continueToken = None,
+                fieldSelector,
+                labelSelector,
+                resourceVersion
+              )
             )
-          )
-          .response(asJsonAccumulating[ObjectList[T]])
-          .send(backend.value)
+            .response(asJsonAccumulating[ObjectList[T]])
+            .send(backend.value)
+        }
       }.map { initialResponse =>
         val rest = ZStream.fromPull {
           for {
@@ -82,19 +84,21 @@ final class ResourceClient[
                                                                    labelSelector,
                                                                    None
                                                                  ) {
-                                                                   k8sRequest
-                                                                     .get(
-                                                                       paginated(
-                                                                         namespace,
-                                                                         chunkSize,
-                                                                         continueToken = Some(token),
-                                                                         fieldSelector,
-                                                                         labelSelector,
-                                                                         resourceVersion
+                                                                   k8sRequest.flatMap { request =>
+                                                                     request
+                                                                       .get(
+                                                                         paginated(
+                                                                           namespace,
+                                                                           chunkSize,
+                                                                           continueToken = Some(token),
+                                                                           fieldSelector,
+                                                                           labelSelector,
+                                                                           resourceVersion
+                                                                         )
                                                                        )
-                                                                     )
-                                                                     .response(asJsonAccumulating[ObjectList[T]])
-                                                                     .send(backend.value)
+                                                                       .response(asJsonAccumulating[ObjectList[T]])
+                                                                       .send(backend.value)
+                                                                   }
                                                                  }.mapError(Some.apply)
                                                           _   <- nextContinueToken.set(lst.metadata.flatMap(_.continue))
                                                         } yield Chunk.fromIterable(lst.items)
@@ -128,13 +132,15 @@ final class ResourceClient[
     ZStream
       .unwrap {
         handleFailures("watch", namespace, fieldSelector, labelSelector, None) {
-          k8sRequest
-            .get(
-              watching(namespace, resourceVersion, fieldSelector, labelSelector, sendInitialEvents)
-            )
-            .response(asStreamUnsafeWithError)
-            .readTimeout(readTimeout.asScala)
-            .send(backend.value)
+          k8sRequest.flatMap { request =>
+            request
+              .get(
+                watching(namespace, resourceVersion, fieldSelector, labelSelector, sendInitialEvents)
+              )
+              .response(asStreamUnsafeWithError)
+              .readTimeout(readTimeout.asScala)
+              .send(backend.value)
+          }
         }.map(_.mapError(RequestFailure(reqInfo, _)))
       }
       .via(
@@ -194,10 +200,12 @@ final class ResourceClient[
 
   def get(name: String, namespace: Option[K8sNamespace]): IO[K8sFailure, T] =
     handleFailures("get", namespace, name) {
-      k8sRequest
-        .get(simple(Some(name), subresource = None, namespace))
-        .response(asJsonAccumulating[T])
-        .send(backend.value)
+      k8sRequest.flatMap { request =>
+        request
+          .get(simple(Some(name), subresource = None, namespace))
+          .response(asJsonAccumulating[T])
+          .send(backend.value)
+      }
     }
 
   override def create(
@@ -206,11 +214,13 @@ final class ResourceClient[
     dryRun: Boolean
   ): IO[K8sFailure, T] =
     handleFailures("create", namespace, None, None, None) {
-      k8sRequest
-        .post(creating(namespace, dryRun))
-        .body(newResource)
-        .response(asJsonAccumulating[T])
-        .send(backend.value)
+      k8sRequest.flatMap { request =>
+        request
+          .post(creating(namespace, dryRun))
+          .body(newResource)
+          .response(asJsonAccumulating[T])
+          .send(backend.value)
+      }
     }
 
   override def replace(
@@ -220,11 +230,13 @@ final class ResourceClient[
     dryRun: Boolean
   ): IO[K8sFailure, T] =
     handleFailures("replace", namespace, name) {
-      k8sRequest
-        .put(modifying(name = name, subresource = None, namespace, dryRun))
-        .body(updatedResource)
-        .response(asJsonAccumulating[T])
-        .send(backend.value)
+      k8sRequest.flatMap { request =>
+        request
+          .put(modifying(name = name, subresource = None, namespace, dryRun))
+          .body(updatedResource)
+          .response(asJsonAccumulating[T])
+          .send(backend.value)
+      }
     }
 
   override def delete(
@@ -236,20 +248,22 @@ final class ResourceClient[
     propagationPolicy: Option[PropagationPolicy] = None
   ): IO[K8sFailure, DeleteResult] =
     handleFailures("delete", namespace, name) {
-      k8sRequest
-        .delete(
-          deleting(
-            name = name,
-            subresource = None,
-            namespace,
-            dryRun,
-            gracePeriod,
-            propagationPolicy
+      k8sRequest.flatMap { request =>
+        request
+          .delete(
+            deleting(
+              name = name,
+              subresource = None,
+              namespace,
+              dryRun,
+              gracePeriod,
+              propagationPolicy
+            )
           )
-        )
-        .body(deleteOptions)
-        .response(asJsonAccumulating[DeleteResult])
-        .send(backend.value)
+          .body(deleteOptions)
+          .response(asJsonAccumulating[DeleteResult])
+          .send(backend.value)
+      }
     }
 
   def deleteAll(
@@ -262,20 +276,22 @@ final class ResourceClient[
     labelSelector: Option[LabelSelector] = None
   ): IO[K8sFailure, Status] =
     handleFailures("deleteAll", namespace, fieldSelector, labelSelector, None) {
-      k8sRequest
-        .delete(
-          deletingMany(
-            namespace,
-            dryRun,
-            gracePeriod,
-            propagationPolicy,
-            fieldSelector,
-            labelSelector
+      k8sRequest.flatMap { request =>
+        request
+          .delete(
+            deletingMany(
+              namespace,
+              dryRun,
+              gracePeriod,
+              propagationPolicy,
+              fieldSelector,
+              labelSelector
+            )
           )
-        )
-        .body(deleteOptions)
-        .response(asJsonAccumulating[Status])
-        .send(backend.value)
+          .body(deleteOptions)
+          .response(asJsonAccumulating[Status])
+          .send(backend.value)
+      }
     }
 }
 

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClient.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClient.scala
@@ -135,7 +135,13 @@ final class ResourceClient[
           k8sRequest.flatMap { request =>
             request
               .get(
-                watching(namespace, resourceVersion, fieldSelector, labelSelector, sendInitialEvents)
+                watching(
+                  namespace,
+                  resourceVersion,
+                  fieldSelector,
+                  labelSelector,
+                  sendInitialEvents
+                )
               )
               .response(asStreamUnsafeWithError)
               .readTimeout(readTimeout.asScala)

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClientBase.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceClientBase.scala
@@ -30,10 +30,10 @@ trait ResourceClientBase {
   protected val cluster: K8sCluster
   protected val backend: K8sBackend
 
-  protected val k8sRequest: RequestT[Empty, Either[String, String], Any] =
+  protected def k8sRequest: Task[RequestT[Empty, Either[String, String], Any]] =
     cluster.applyToken match {
       case Some(f) => f(basicRequest)
-      case None    => basicRequest
+      case None    => ZIO.succeed(basicRequest)
     }
 
   protected def simple(
@@ -145,29 +145,42 @@ trait ResourceClientBase {
   ): IO[K8sFailure, A] = {
     val reqInfo =
       K8sRequestInfo(resourceType, operation, namespace, fieldSelector, labelSelector, name)
-    f.mapError(RequestFailure.apply(reqInfo, _))
-      .flatMap { response =>
-        response.body match {
-          case Left(HttpError(error, StatusCode.Unauthorized)) =>
-            ZIO.fail(Unauthorized(reqInfo, error))
-          case Left(HttpError(_, StatusCode.Gone))             =>
-            ZIO.fail(Gone)
-          case Left(HttpError(_, StatusCode.NotFound))         =>
-            ZIO.fail(NotFound)
-          case Left(HttpError(error, code))                    =>
-            decode[Status](error) match {
-              case Left(_)       =>
-                ZIO.fail(HttpFailure(reqInfo, error, code))
-              case Right(status) =>
-                ZIO.fail(DecodedFailure(reqInfo, status, code))
-            }
-          case Left(DeserializationException(_, errors))       =>
-            ZIO.fail(DeserializationFailure(reqInfo, errors))
-          case Right(value)                                    =>
-            ZIO.succeed(value)
-        }
+    val runRequest = f.mapError(RequestFailure.apply(reqInfo, _))
+    runRequest.flatMap { response =>
+      response.body match {
+        case Left(HttpError(_, StatusCode.Unauthorized)) if cluster.invalidateToken.isDefined =>
+          cluster.invalidateToken.get
+            .mapError(RequestFailure.apply(reqInfo, _)) *>
+            runRequest.flatMap(responseAfterRetry => decodeResponse(reqInfo, responseAfterRetry))
+        case _                                                                                =>
+          decodeResponse(reqInfo, response)
       }
+    }
   }
+
+  private def decodeResponse[A](
+    reqInfo: K8sRequestInfo,
+    response: Response[Either[ResponseException[String, NonEmptyList[Error]], A]]
+  ): IO[K8sFailure, A] =
+    response.body match {
+      case Left(HttpError(error, StatusCode.Unauthorized)) =>
+        ZIO.fail(Unauthorized(reqInfo, error))
+      case Left(HttpError(_, StatusCode.Gone))             =>
+        ZIO.fail(Gone)
+      case Left(HttpError(_, StatusCode.NotFound))         =>
+        ZIO.fail(NotFound)
+      case Left(HttpError(error, code))                    =>
+        decode[Status](error) match {
+          case Left(_)       =>
+            ZIO.fail(HttpFailure(reqInfo, error, code))
+          case Right(status) =>
+            ZIO.fail(DecodedFailure(reqInfo, status, code))
+        }
+      case Left(DeserializationException(_, errors))       =>
+        ZIO.fail(DeserializationFailure(reqInfo, errors))
+      case Right(value)                                    =>
+        ZIO.succeed(value)
+    }
 
   /** If the response is successful (2xx), tries to deserialize the body from a string into JSON.
     * Returns:

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceStatusClient.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/impl/ResourceStatusClient.scala
@@ -36,20 +36,26 @@ final class ResourceStatusClient[StatusT: Encoder, T: K8sObject: Encoder: Decode
     for {
       name     <- of.getName
       response <- handleFailures("replaceStatus", namespace, None, None, None) {
-                    k8sRequest
-                      .put(modifying(name = name, subresource = Some("status"), namespace, dryRun))
-                      .body(toStatusUpdate(of, updatedStatus))
-                      .response(asJsonAccumulating[T])
-                      .send(backend.value)
+                    k8sRequest.flatMap { request =>
+                      request
+                        .put(
+                          modifying(name = name, subresource = Some("status"), namespace, dryRun)
+                        )
+                        .body(toStatusUpdate(of, updatedStatus))
+                        .response(asJsonAccumulating[T])
+                        .send(backend.value)
+                    }
                   }
     } yield response
 
   override def getStatus(name: String, namespace: Option[K8sNamespace]): IO[K8sFailure, T] =
     handleFailures("getStatus", namespace, name) {
-      k8sRequest
-        .get(simple(Some(name), subresource = Some("status"), namespace))
-        .response(asJsonAccumulating[T])
-        .send(backend.value)
+      k8sRequest.flatMap { request =>
+        request
+          .get(simple(Some(name), subresource = Some("status"), namespace))
+          .response(asJsonAccumulating[T])
+          .send(backend.value)
+      }
     }
 
   private def toStatusUpdate(of: T, newStatus: StatusT): Json =

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/model/package.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/model/package.scala
@@ -20,12 +20,17 @@ package object model extends LabelSelector.Syntax with FieldSelector.Syntax {
     *   Host to connect to
     * @param applyToken
     *   Function to apply an authentication token to the HTTP request
+    * @param invalidateToken
+    *   Optional hook to force token refresh on auth failures
     */
   case class K8sCluster(
     host: Uri,
     applyToken: Option[
-      RequestT[Empty, Either[String, String], Any] => RequestT[Empty, Either[String, String], Any]
-    ]
+      RequestT[Empty, Either[String, String], Any] => Task[
+        RequestT[Empty, Either[String, String], Any]
+      ]
+    ],
+    invalidateToken: Option[Task[Unit]] = None
   )
 
   /** Metadata identifying a Kubernetes resource

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/ConfigSpec.scala
@@ -7,7 +7,15 @@ import io.circe.yaml.parser.parse
 import sttp.client3._
 import zio.config.typesafe.TypesafeConfigProvider
 import zio.nio.file.{ Files, Path }
-import zio.test.{ assertCompletes, assertZIO, Assertion, Spec, TestClock, TestEnvironment, ZIOSpecDefault }
+import zio.test.{
+  assertCompletes,
+  assertZIO,
+  Assertion,
+  Spec,
+  TestClock,
+  TestEnvironment,
+  ZIOSpecDefault
+}
 import zio._
 
 import java.nio.charset.StandardCharsets
@@ -123,7 +131,8 @@ object ConfigSpec extends ZIOSpecDefault {
             K8sClusterConfig(
               uri"https://kubernetes.default.svc",
               authentication = K8sAuthentication.ServiceAccountToken(
-                token = KeySource.FromFile(Path("/var/run/secrets/kubernetes.io/serviceaccount/token")),
+                token =
+                  KeySource.FromFile(Path("/var/run/secrets/kubernetes.io/serviceaccount/token")),
                 tokenCacheSeconds = 5
               ),
               client = K8sClientConfig(

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/impl/ResourceClientBaseSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/impl/ResourceClientBaseSpec.scala
@@ -25,9 +25,7 @@ object ResourceClientBaseSpec extends ZIOSpecDefault {
           override protected val cluster: K8sCluster =
             K8sCluster(
               uri"https://kubernetes.default.svc",
-              Some(request =>
-                ZIO.succeed(request.auth.bearer(s"token-${index.incrementAndGet()}"))
-              )
+              Some(request => ZIO.succeed(request.auth.bearer(s"token-${index.incrementAndGet()}")))
             )
           override protected val backend: K8sBackend =
             K8sBackend(

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/impl/ResourceClientBaseSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/impl/ResourceClientBaseSpec.scala
@@ -1,0 +1,91 @@
+package com.coralogix.zio.k8s.client.impl
+
+import cats.data.NonEmptyList
+import com.coralogix.zio.k8s.client.K8sFailure
+import com.coralogix.zio.k8s.client.config.backend.K8sBackend
+import com.coralogix.zio.k8s.client.model.{ K8sCluster, K8sResourceType }
+import io.circe.Error
+import sttp.capabilities.WebSockets
+import sttp.capabilities.zio.ZioStreams
+import sttp.client3._
+import sttp.model.StatusCode
+import zio._
+import zio.test._
+
+import java.util.concurrent.atomic.AtomicInteger
+
+object ResourceClientBaseSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("ResourceClientBase")(
+      test("builds a fresh request on each access") {
+        val index = new AtomicInteger(0)
+
+        final class AuthorizationClient extends ResourceClientBase {
+          override protected val resourceType: K8sResourceType = K8sResourceType("pods", "", "v1")
+          override protected val cluster: K8sCluster =
+            K8sCluster(
+              uri"https://kubernetes.default.svc",
+              Some(request =>
+                ZIO.succeed(request.auth.bearer(s"token-${index.incrementAndGet()}"))
+              )
+            )
+          override protected val backend: K8sBackend =
+            K8sBackend(
+              null.asInstanceOf[SttpBackend[Task, ZioStreams with WebSockets]]
+            )
+
+          def authorization: Task[Option[String]] =
+            k8sRequest.map(
+              _.headers
+                .find(_.is("Authorization"))
+                .map(_.value)
+            )
+        }
+        val client = new AuthorizationClient
+
+        assertZIO(client.authorization.zip(client.authorization))(
+          Assertion.equalTo((Some("Bearer token-1"), Some("Bearer token-2")))
+        )
+      },
+      test("retries once after unauthorized and token invalidation") {
+        type ResponseBody = Either[ResponseException[String, NonEmptyList[Error]], String]
+
+        val attempts = new AtomicInteger(0)
+        val invalidations = new AtomicInteger(0)
+
+        final class RetryClient extends ResourceClientBase {
+          override protected val resourceType: K8sResourceType = K8sResourceType("pods", "", "v1")
+          override protected val cluster: K8sCluster =
+            K8sCluster(
+              uri"https://kubernetes.default.svc",
+              None,
+              Some(ZIO.succeed(invalidations.incrementAndGet()).unit)
+            )
+          override protected val backend: K8sBackend =
+            K8sBackend(
+              null.asInstanceOf[SttpBackend[Task, ZioStreams with WebSockets]]
+            )
+
+          def run(request: Task[Response[ResponseBody]]): IO[K8sFailure, String] =
+            handleFailures("get", None, "pod1")(request)
+        }
+        val client = new RetryClient
+
+        val unauthorizedResponse: Response[ResponseBody] =
+          Response(
+            Left(HttpError("expired token", StatusCode.Unauthorized)),
+            StatusCode.Unauthorized
+          )
+        val successfulResponse: Response[ResponseBody] =
+          Response(Right("ok"), StatusCode.Ok)
+        val requestTask: Task[Response[ResponseBody]] =
+          ZIO.succeed {
+            if (attempts.incrementAndGet() == 1) unauthorizedResponse else successfulResponse
+          }
+
+        assertZIO(
+          client.run(requestTask).map(value => (value, attempts.get(), invalidations.get()))
+        )(Assertion.equalTo(("ok", 2, 1)))
+      }
+    )
+}


### PR DESCRIPTION
- Make K8sCluster auth application effectful and add optional token invalidation hook
- Add service-account token cache TTL (tokenCacheSeconds) with Ref + Clock time for file tokens
- Retry once on Unauthorized after invalidating refreshable token state
- Update all request builders to rebuild/authenticate per request
- Extend ConfigSpec for token cache/reload behavior and add ResourceClientBaseSpec for retry semantics
- Document tokenCacheSeconds in getting started config examples

BREAKING:
- K8sCluster.applyToken is now effectful (returns Task[RequestT]) and K8sCluster includes invalidateToken.
- K8sAuthentication.ServiceAccountToken now takes tokenCacheSeconds (default 0).
- ResourceClientBase.k8sRequest changed from RequestT to Task[RequestT], affecting custom extensions/subclasses.