### PR TITLE
Make client certificate private-key loading provider-neutral

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,6 @@ lazy val client = Project("zio-k8s-client", file("zio-k8s-client"))
       "io.circe"                      %% "circe-generic"                 % "0.14.15",
       "io.circe"                      %% "circe-parser"                  % "0.14.15",
       "io.circe"                      %% "circe-yaml"                    % "0.14.2",
-      "org.bouncycastle"               % "bcpkix-jdk18on"                % "1.84",
       "dev.zio"                       %% "zio-config-typesafe"           % zioConfigVersion % Test,
       "dev.zio"                       %% "zio-test"                      % zioVersion       % Test,
       "dev.zio"                       %% "zio-test-sbt"                  % zioVersion       % Test,

--- a/docs/overview/gettingstarted.md
+++ b/docs/overview/gettingstarted.md
@@ -173,6 +173,29 @@ k8s {
 }
 ```
 
+### Client certificate private-key formats
+
+When using `K8sAuthentication.ClientCertificates` or the kubeconfig `client-key` and
+`client-key-data` fields, zio-k8s accepts the following unencrypted PEM private-key
+formats:
+
+| PEM type | Encoding | Supported key algorithm |
+| --- | --- | --- |
+| `PRIVATE KEY` | PKCS#8 | Any algorithm available through a registered JCA `KeyFactory` |
+| `RSA PRIVATE KEY` | PKCS#1 | RSA |
+| `EC PRIVATE KEY` | SEC1 | EC |
+
+Encrypted PEM keys and other algorithm-specific traditional formats, including
+`DSA PRIVATE KEY`, are not supported. `K8sAuthentication.ClientCertificates.password`
+does not decrypt PEM input. Convert a legacy unencrypted private key to PKCS#8 before
+using it:
+
+```shell
+openssl pkcs8 -topk8 -nocrypt \
+  -in legacy-private-key.pem \
+  -out private-key.pkcs8.pem
+```
+
 ## Clients
 
 The above created `k8sLayers` can be fed to any of the `zio-k8s` **client modules**

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/KeyManagers.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/KeyManagers.scala
@@ -1,13 +1,9 @@
 package com.coralogix.zio.k8s.client.config
 
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
-import org.bouncycastle.openssl.{ PEMKeyPair, PEMParser }
 import zio.{ System, ZIO }
 
-import java.io.{ File, FileInputStream, InputStreamReader }
-import java.security.KeyStore
+import java.io.{ File, FileInputStream }
+import java.security.{ KeyStore, PrivateKey, PublicKey }
 import java.security.cert.{ CertificateFactory, X509Certificate }
 import javax.net.ssl.{ KeyManager, KeyManagerFactory }
 
@@ -39,41 +35,34 @@ private object KeyManagers {
     password: Option[String]
   ): ZIO[Any, Throwable, Array[KeyManager]] =
     for {
-      keyStore <- getDefaultKeyStore
-      provider <- ZIO.attempt(new BouncyCastleProvider())
-
-      privateKey <- ZIO.scoped(loadKeyStream(key) flatMap { stream =>
-                      ZIO.attempt {
-                        val pemKeyPair = new PEMParser(new InputStreamReader(stream))
-                        val converter = new JcaPEMKeyConverter().setProvider(provider)
-                        pemKeyPair.readObject() match {
-                          case pair: PEMKeyPair   => converter.getPrivateKey(pair.getPrivateKeyInfo)
-                          case pk: PrivateKeyInfo => converter.getPrivateKey(pk)
-                          case other: Any         =>
-                            throw new IllegalStateException(
-                              s"Unexpected key pair type ${other.getClass.getSimpleName}"
-                            )
-                        }
-                      }
-                    })
-
+      keyStore           <- getDefaultKeyStore
+      keyPassword         = password.getOrElse("changeit").toCharArray
       certificateFactory <- ZIO.attempt(CertificateFactory.getInstance("X509"))
       x509Cert           <- ZIO.scoped(loadKeyStream(certificate) flatMap { stream =>
                               ZIO.attempt(
                                 certificateFactory.generateCertificate(stream).asInstanceOf[X509Certificate]
                               )
                             })
+      privateKey         <- ZIO.scoped(loadPrivateKey(key, x509Cert.getPublicKey))
 
       _ <- ZIO.attempt {
              keyStore.setKeyEntry(
                x509Cert.getIssuerX500Principal.getName,
                privateKey,
-               password.getOrElse("changeit").toCharArray,
+               keyPassword,
                Array(x509Cert)
              )
            }
 
       kmf <- ZIO.attempt(KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm))
-      _   <- ZIO.attempt(kmf.init(keyStore, "changeit".toCharArray))
+      _   <- ZIO.attempt(kmf.init(keyStore, keyPassword))
     } yield kmf.getKeyManagers
+
+  private[config] def loadPrivateKey(
+    key: KeySource,
+    publicKey: PublicKey
+  ): ZIO[zio.Scope, Throwable, PrivateKey] =
+    loadKeyStream(key) flatMap { stream =>
+      ZIO.attempt(PrivateKeyDecoder.decode(stream, publicKey))
+    }
 }

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/PrivateKeyDecoder.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/PrivateKeyDecoder.scala
@@ -1,0 +1,268 @@
+package com.coralogix.zio.k8s.client.config
+
+import java.io.InputStream
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.security.interfaces.{ ECPublicKey, RSAPublicKey }
+import java.security.spec.{ ECPrivateKeySpec, PKCS8EncodedKeySpec, RSAPrivateCrtKeySpec }
+import java.security.{ KeyFactory, PrivateKey, PublicKey }
+import java.util.{ Arrays, Base64 }
+import java.util.regex.Pattern
+
+private[config] trait PrivateKeyDecoder {
+  def decode(input: InputStream, publicKey: PublicKey): PrivateKey
+}
+
+private[config] object PrivateKeyDecoder extends PrivateKeyDecoder {
+  private val PemHeader = Pattern.compile("-----BEGIN ([A-Z0-9 ]+)-----")
+
+  override def decode(input: InputStream, publicKey: PublicKey): PrivateKey = {
+    val pem = readPem(input)
+
+    pem.label match {
+      case "PRIVATE KEY"           => decodePkcs8(pem.bytes, publicKey)
+      case "RSA PRIVATE KEY"       => decodeRsaPkcs1(pem.bytes, publicKey)
+      case "EC PRIVATE KEY"        => decodeEcSec1(pem.bytes, publicKey)
+      case "ENCRYPTED PRIVATE KEY" =>
+        fail("Encrypted private keys are not supported")
+      case other                   =>
+        fail(
+          s"Unsupported PEM label '$other'; expected PRIVATE KEY, RSA PRIVATE KEY, or EC PRIVATE KEY"
+        )
+    }
+  }
+
+  private def decodeEcSec1(bytes: Array[Byte], publicKey: PublicKey): PrivateKey =
+    publicKey match {
+      case ecPublicKey: ECPublicKey =>
+        val root = new DerReader(bytes)
+        val sequence = root.readSequence("EC private key")
+        val version = sequence.readInteger("EC private key version")
+        if (version != BigInteger.ONE) {
+          fail(s"Unsupported EC private key version $version")
+        }
+
+        val scalarBytes = sequence.readOctetString("EC private key scalar")
+        if (scalarBytes.isEmpty) {
+          fail("EC private key scalar must not be empty")
+        }
+
+        // SEC1 permits optional curve parameters and a public key after the private scalar.
+        while (sequence.hasRemaining)
+          sequence.skipElement(Set(0xa0, 0xa1), "EC private key optional field")
+        root.requireEnd("EC private key")
+
+        val scalar = new BigInteger(1, scalarBytes)
+        if (scalar.signum() <= 0 || scalar.compareTo(ecPublicKey.getParams.getOrder) >= 0) {
+          fail("EC private key scalar is outside the certificate curve's valid range")
+        }
+
+        val keySpec = new ECPrivateKeySpec(scalar, ecPublicKey.getParams)
+        KeyFactory.getInstance("EC").generatePrivate(keySpec)
+      case _                        =>
+        fail("An EC PRIVATE KEY requires an EC client certificate")
+    }
+
+  private def decodePkcs8(bytes: Array[Byte], publicKey: PublicKey): PrivateKey = {
+    // The certificate identifies the algorithm without parsing the PKCS#8 AlgorithmIdentifier.
+    val keyFactory = KeyFactory.getInstance(publicKey.getAlgorithm)
+    keyFactory.generatePrivate(new PKCS8EncodedKeySpec(bytes))
+  }
+
+  private def decodeRsaPkcs1(bytes: Array[Byte], publicKey: PublicKey): PrivateKey =
+    publicKey match {
+      case rsaPublicKey: RSAPublicKey =>
+        val root = new DerReader(bytes)
+        val sequence = root.readSequence("RSA private key")
+        val version = sequence.readInteger("RSA private key version")
+        val modulus = sequence.readPositiveInteger("RSA modulus")
+        val publicExponent = sequence.readPositiveInteger("RSA public exponent")
+        val keySpec = new RSAPrivateCrtKeySpec(
+          modulus,
+          publicExponent,
+          sequence.readPositiveInteger("RSA private exponent"),
+          sequence.readPositiveInteger("RSA prime P"),
+          sequence.readPositiveInteger("RSA prime Q"),
+          sequence.readPositiveInteger("RSA prime exponent P"),
+          sequence.readPositiveInteger("RSA prime exponent Q"),
+          sequence.readPositiveInteger("RSA CRT coefficient")
+        )
+
+        if (version != BigInteger.ZERO) {
+          fail(s"Unsupported RSA private key version $version")
+        }
+        sequence.requireEnd("RSA private key")
+        root.requireEnd("RSA private key")
+
+        if (
+          modulus != rsaPublicKey.getModulus ||
+          publicExponent != rsaPublicKey.getPublicExponent
+        ) {
+          fail("RSA private key does not match the client certificate")
+        }
+
+        KeyFactory.getInstance("RSA").generatePrivate(keySpec)
+      case _                          =>
+        fail("An RSA PRIVATE KEY requires an RSA client certificate")
+    }
+
+  private def fail(message: String): Nothing =
+    throw new IllegalArgumentException(message)
+
+  private def isAsciiWhitespace(character: Char): Boolean =
+    character == ' ' || character == '\t' || character == '\r' || character == '\n'
+
+  private def isBase64Character(character: Char): Boolean =
+    (character >= 'A' && character <= 'Z') ||
+      (character >= 'a' && character <= 'z') ||
+      (character >= '0' && character <= '9') ||
+      character == '+' || character == '/' || character == '='
+
+  private def readPem(input: InputStream): Pem = {
+    val value = new String(input.readAllBytes(), StandardCharsets.US_ASCII)
+    val matcher = PemHeader.matcher(value)
+    if (!matcher.find()) {
+      fail("Private key is not PEM encoded")
+    }
+    if (!value.substring(0, matcher.start()).forall(isAsciiWhitespace)) {
+      fail("Unexpected content before the PEM header")
+    }
+
+    val label = matcher.group(1)
+    val footer = s"-----END $label-----"
+    val footerStart = value.indexOf(footer, matcher.end())
+    if (footerStart < 0) {
+      fail(s"Missing PEM footer for '$label'")
+    }
+    if (!value.substring(footerStart + footer.length).forall(isAsciiWhitespace)) {
+      fail("Unexpected content after the PEM footer")
+    }
+
+    val encoded = value
+      .substring(matcher.end(), footerStart)
+      .iterator
+      .filterNot(isAsciiWhitespace)
+      .mkString
+    if (encoded.isEmpty || !encoded.forall(isBase64Character)) {
+      fail("PEM body is not valid Base64")
+    }
+
+    val bytes =
+      try Base64.getDecoder.decode(encoded)
+      catch {
+        case _: IllegalArgumentException => fail("PEM body is not valid Base64")
+      }
+    Pem(label, bytes)
+  }
+
+  private final case class Pem(label: String, bytes: Array[Byte])
+
+  /** Minimal, bounded DER reader for the two traditional private-key formats supported above. */
+  private final class DerReader(bytes: Array[Byte]) {
+    private var offset = 0
+
+    def hasRemaining: Boolean = offset < bytes.length
+
+    def readInteger(description: String): BigInteger = {
+      val encoded = readValue(0x02, description)
+      if (encoded.isEmpty) {
+        fail(s"$description must not be empty")
+      }
+      if (
+        encoded.length > 1 &&
+        ((encoded(0) == 0.toByte && (encoded(1) & 0x80) == 0) ||
+          (encoded(0) == 0xff.toByte && (encoded(1) & 0x80) != 0))
+      ) {
+        fail(s"$description is not minimally encoded")
+      }
+      new BigInteger(encoded)
+    }
+
+    def readOctetString(description: String): Array[Byte] =
+      readValue(0x04, description)
+
+    def readPositiveInteger(description: String): BigInteger = {
+      val integer = readInteger(description)
+      if (integer.signum() <= 0) {
+        fail(s"$description must be positive")
+      }
+      integer
+    }
+
+    def readSequence(description: String): DerReader =
+      new DerReader(readValue(0x30, description))
+
+    def requireEnd(description: String): Unit =
+      if (hasRemaining) {
+        fail(s"Unexpected trailing data in $description")
+      }
+
+    def skipElement(allowedTags: Set[Int], description: String): Unit = {
+      val tag = readUnsignedByte(description)
+      if (!allowedTags.contains(tag)) {
+        fail(f"Unexpected DER tag 0x$tag%02x in $description")
+      }
+      skip(readLength(description), description)
+    }
+
+    private def readLength(description: String): Int = {
+      val first = readUnsignedByte(description)
+      if ((first & 0x80) == 0) {
+        first
+      } else {
+        val count = first & 0x7f
+        if (count == 0) {
+          fail(s"Indefinite DER length is not permitted in $description")
+        }
+        if (count > 4 || count > bytes.length - offset) {
+          fail(s"Invalid DER length in $description")
+        }
+
+        var length = 0L
+        var index = 0
+        while (index < count) {
+          val next = readUnsignedByte(description)
+          if (index == 0 && next == 0) {
+            fail(s"Non-minimal DER length in $description")
+          }
+          length = (length << 8) | next.toLong
+          index += 1
+        }
+        if (length < 128 || length > Int.MaxValue) {
+          fail(s"Invalid DER length in $description")
+        }
+        length.toInt
+      }
+    }
+
+    private def readUnsignedByte(description: String): Int = {
+      if (!hasRemaining) {
+        fail(s"Unexpected end of DER data in $description")
+      }
+      val value = bytes(offset) & 0xff
+      offset += 1
+      value
+    }
+
+    private def readValue(expectedTag: Int, description: String): Array[Byte] = {
+      val tag = readUnsignedByte(description)
+      if (tag != expectedTag) {
+        fail(f"Unexpected DER tag 0x$tag%02x in $description")
+      }
+      val length = readLength(description)
+      if (length > bytes.length - offset) {
+        fail(s"DER length exceeds the available data in $description")
+      }
+      val value = Arrays.copyOfRange(bytes, offset, offset + length)
+      offset += length
+      value
+    }
+
+    private def skip(length: Int, description: String): Unit = {
+      if (length > bytes.length - offset) {
+        fail(s"DER length exceeds the available data in $description")
+      }
+      offset += length
+    }
+  }
+}

--- a/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
+++ b/zio-k8s-client/src/main/scala/com/coralogix/zio/k8s/client/config/package.scala
@@ -105,12 +105,17 @@ package object config extends Descriptors {
       * See
       * https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs
       *
+      * Private keys must use an unencrypted PEM encoding. Supported PEM types are PKCS#8 `PRIVATE
+      * KEY`, PKCS#1 `RSA PRIVATE KEY`, and SEC1 `EC PRIVATE KEY`. PKCS#8 keys are decoded through
+      * the registered JCA providers, so their algorithm must have an available `KeyFactory`
+      * implementation.
+      *
       * @param certificate
       *   Client certificate
       * @param key
       *   Client's private key
       * @param password
-      *   Passphrase for the key if needed
+      *   Password for the loaded key entry. This does not enable encrypted PEM key decoding.
       */
     final case class ClientCertificates(
       certificate: KeySource,

--- a/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/KeyManagersSpec.scala
+++ b/zio-k8s-client/src/test/scala/com/coralogix/zio/k8s/client/config/KeyManagersSpec.scala
@@ -1,0 +1,206 @@
+package com.coralogix.zio.k8s.client.config
+
+import com.coralogix.zio.k8s.client.config.KeySource.FromString
+import zio.ZIO
+import zio.test.{ assertTrue, Spec, TestEnvironment, ZIOSpecDefault }
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+import java.security.spec.KeySpec
+import java.security.{ Key, KeyFactory, KeyFactorySpi, PrivateKey, Provider, PublicKey, Security }
+import java.security.cert.{ CertificateFactory, X509Certificate }
+import java.util.concurrent.atomic.AtomicBoolean
+
+object KeyManagersSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment, Any] =
+    suite("KeyManagers")(
+      test("builds key managers from PKCS#1 RSA private keys") {
+        KeyManagers(
+          FromString(rsaCertificate),
+          FromString(rsaPkcs1PrivateKey),
+          None
+        ).map(keyManagers => assertTrue(keyManagers.nonEmpty))
+      },
+      test("builds key managers from SEC1 EC private keys") {
+        KeyManagers(
+          FromString(ecCertificate),
+          FromString(ecSec1PrivateKey),
+          None
+        ).map(keyManagers => assertTrue(keyManagers.nonEmpty))
+      },
+      test("builds key managers with a custom key password") {
+        KeyManagers(
+          FromString(ecCertificate),
+          FromString(ecSec1PrivateKey),
+          Some("custom-password")
+        ).map(keyManagers => assertTrue(keyManagers.nonEmpty))
+      },
+      test("rejects malformed traditional private keys") {
+        for {
+          publicKey <- loadPublicKey(rsaCertificate)
+          result    <- ZIO
+                         .scoped(
+                           KeyManagers.loadPrivateKey(FromString(malformedRsaPrivateKey), publicKey)
+                         )
+                         .exit
+        } yield assertTrue(result.isFailure)
+      },
+      test("uses registered JCA providers to decode private keys") {
+        ZIO.scoped {
+          ZIO
+            .acquireRelease(
+              ZIO.attempt {
+                Security.removeProvider(TrackingProvider.Name)
+                TrackingRsaKeyFactorySpi.prepare()
+                val position = Security.addProvider(new TrackingProvider())
+                if (position == -1) {
+                  throw new IllegalStateException("Unable to register tracking JCA provider")
+                }
+              }
+            )(_ => ZIO.succeed(Security.removeProvider(TrackingProvider.Name))) *>
+            loadPublicKey(rsaCertificate).flatMap { publicKey =>
+              KeyManagers
+                .loadPrivateKey(
+                  FromString(rsaPkcs8PrivateKey),
+                  new TrackingPublicKey(publicKey)
+                )
+                .as(assertTrue(TrackingRsaKeyFactorySpi.wasUsed))
+            }
+        }
+      }
+    )
+
+  private def loadPublicKey(certificate: String): ZIO[Any, Throwable, PublicKey] =
+    ZIO.attempt {
+      val stream = new ByteArrayInputStream(certificate.getBytes(StandardCharsets.US_ASCII))
+      try
+        CertificateFactory
+          .getInstance("X509")
+          .generateCertificate(stream)
+          .asInstanceOf[X509Certificate]
+          .getPublicKey
+      finally stream.close()
+    }
+
+  private val ecCertificate =
+    """-----BEGIN CERTIFICATE-----
+      |MIIBIzCBygIJAK3oTMheLiVkMAoGCCqGSM49BAMCMBoxGDAWBgNVBAMMD3ppby1r
+      |OHMtZWMtdGVzdDAeFw0yNjA3MTYyMDQxNDdaFw0zNjA3MTMyMDQxNDdaMBoxGDAW
+      |BgNVBAMMD3ppby1rOHMtZWMtdGVzdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA
+      |BGeggQAdGvOx7Y6QbkgNK2n+HlFpeqnJg0V1SwHV872ukwV249UksrDEpCDPSl6r
+      |KvWUgLvVf6rLYZBnSV2TjDIwCgYIKoZIzj0EAwIDSAAwRQIhAM6mlmIo5YeY7+ac
+      |5/w5su4TuXAx2Z42hZp9cbJnDPYSAiBKAl0mVyfmx/b/mf/tcuLxvSnObHqMmE4m
+      |KpHq1I66JA==
+      |-----END CERTIFICATE-----""".stripMargin
+
+  private val ecSec1PrivateKey =
+    """-----BEGIN EC PRIVATE KEY-----
+      |MHcCAQEEILseYGKgpM5g5DZKkxHgTRLUthUuINPDmLg0iWJh35pEoAoGCCqGSM49
+      |AwEHoUQDQgAEZ6CBAB0a87HtjpBuSA0raf4eUWl6qcmDRXVLAdXzva6TBXbj1SSy
+      |sMSkIM9KXqsq9ZSAu9V/qsthkGdJXZOMMg==
+      |-----END EC PRIVATE KEY-----""".stripMargin
+
+  private val malformedRsaPrivateKey =
+    """-----BEGIN RSA PRIVATE KEY-----
+      |MAMCAQA=
+      |-----END RSA PRIVATE KEY-----""".stripMargin
+
+  private val rsaCertificate =
+    """-----BEGIN CERTIFICATE-----
+      |MIIBtzCCASACCQC5z+iCPMmYLzANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBV6
+      |aW8tazhzLXByb3ZpZGVyLXRlc3QwHhcNMjYwNzE2MTk0MDU0WhcNMzYwNzEzMTk0
+      |MDU0WjAgMR4wHAYDVQQDDBV6aW8tazhzLXByb3ZpZGVyLXRlc3QwgZ8wDQYJKoZI
+      |hvcNAQEBBQADgY0AMIGJAoGBAMsl74IENbnNryKYlZqLRzDzvkJhJCtaFb3xqmjE
+      |1BQd2k52uPiNlw6C3Oi0mxltW5nBGG82t88N3EyfA4eMWVWSN0iRliNPBATPnCtG
+      |kUBNBUfwUcE2Zl6uQXYNmne4s61em6erV7tEcGfZk40pwt6ZTGH+EUAqkDRPKYlo
+      |7AifAgMBAAEwDQYJKoZIhvcNAQELBQADgYEAJF8mlhFjPq+YjKxGrwy21o3OaX4X
+      |7NYT4DUGAA1cKHbs007ynBunnUDplM4s1vRljYvTbZMSpYAEJcGfkyrnuU3jhB6i
+      |ufvvglJd53hBaX+uiqLU662ySDfpr//2JT2GuvtYYUEidM1uv4KmhHuRnBD4nNL4
+      |Nc7oFmRlagZ81ME=
+      |-----END CERTIFICATE-----""".stripMargin
+
+  private val rsaPkcs1PrivateKey =
+    """-----BEGIN RSA PRIVATE KEY-----
+      |MIICXQIBAAKBgQDLJe+CBDW5za8imJWai0cw875CYSQrWhW98apoxNQUHdpOdrj4
+      |jZcOgtzotJsZbVuZwRhvNrfPDdxMnwOHjFlVkjdIkZYjTwQEz5wrRpFATQVH8FHB
+      |NmZerkF2DZp3uLOtXpunq1e7RHBn2ZONKcLemUxh/hFAKpA0TymJaOwInwIDAQAB
+      |AoGBAMKCWiclHMQA2rXHX0cQIGQQnZU1KcqQgMzTvZR/EYkJZGNIbace+wmb5ySw
+      |+OiJuvEm39xsieYooUyD3H9GtKjyB4/7/jAAsdf5svhBWnjvb5pSU+6wVGZA8JV4
+      |gu/cOnD1z3064dYGRACWOgbFTAqB1wZjXzSiHwqcYrXiUtJhAkEA+C+YMU/lR/hX
+      |cNQOZChv0QL331GhnA/y9/e7eBg/s2LyDLnGBGtGBhbEdbhY9butoqEBFqD9SU41
+      |uQK9Lk1KuQJBANGLVQJkXd6yvMj/FSf7OY2Kkzn1nkJ08UqrtoQk1VpeCOf9AdCS
+      |pv+6GEF0MjDNRMyopwH3XSwQbGGZkPab4hcCQFovuWdZ+CByDxxSArTEuPVD1d0R
+      |5d83MHyJSld2wFcognq7W0ipzrVRuqxog/Mv8wXg6etWLxRfVkhXxXU44wkCQCiv
+      |qhjlzggwolFQnhX+RKWD86Q8WbdDp5o9DxpHYJnESmxpBtItt3lN8+m5mwk4whQO
+      |5yaNliy5H6IvxCLuD48CQQCMdOmtovE3cEX3w+ksmESA4iTEsuc4DFuJ7Sm5lSiW
+      |MBjcsSSWK247TFla7J8ZNKKnX7lIrcHwBPBiTngwwePz
+      |-----END RSA PRIVATE KEY-----""".stripMargin
+
+  private val rsaPkcs8PrivateKey =
+    """-----BEGIN PRIVATE KEY-----
+      |MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAMsl74IENbnNryKY
+      |lZqLRzDzvkJhJCtaFb3xqmjE1BQd2k52uPiNlw6C3Oi0mxltW5nBGG82t88N3Eyf
+      |A4eMWVWSN0iRliNPBATPnCtGkUBNBUfwUcE2Zl6uQXYNmne4s61em6erV7tEcGfZ
+      |k40pwt6ZTGH+EUAqkDRPKYlo7AifAgMBAAECgYEAwoJaJyUcxADatcdfRxAgZBCd
+      |lTUpypCAzNO9lH8RiQlkY0htpx77CZvnJLD46Im68Sbf3GyJ5iihTIPcf0a0qPIH
+      |j/v+MACx1/my+EFaeO9vmlJT7rBUZkDwlXiC79w6cPXPfTrh1gZEAJY6BsVMCoHX
+      |BmNfNKIfCpxiteJS0mECQQD4L5gxT+VH+Fdw1A5kKG/RAvffUaGcD/L397t4GD+z
+      |YvIMucYEa0YGFsR1uFj1u62ioQEWoP1JTjW5Ar0uTUq5AkEA0YtVAmRd3rK8yP8V
+      |J/s5jYqTOfWeQnTxSqu2hCTVWl4I5/0B0JKm/7oYQXQyMM1EzKinAfddLBBsYZmQ
+      |9pviFwJAWi+5Z1n4IHIPHFICtMS49UPV3RHl3zcwfIlKV3bAVyiCertbSKnOtVG6
+      |rGiD8y/zBeDp61YvFF9WSFfFdTjjCQJAKK+qGOXOCDCiUVCeFf5EpYPzpDxZt0On
+      |mj0PGkdgmcRKbGkG0i23eU3z6bmbCTjCFA7nJo2WLLkfoi/EIu4PjwJBAIx06a2i
+      |8TdwRffD6SyYRIDiJMSy5zgMW4ntKbmVKJYwGNyxJJYrbjtMWVrsnxk0oqdfuUit
+      |wfAE8GJOeDDB4/M=
+      |-----END PRIVATE KEY-----""".stripMargin
+}
+
+final class TrackingProvider
+    extends Provider(
+      TrackingProvider.Name,
+      "1.0",
+      "Tracks provider-neutral private-key conversion"
+    ) {
+  put(s"KeyFactory.${TrackingProvider.Algorithm}", classOf[TrackingRsaKeyFactorySpi].getName)
+}
+
+object TrackingProvider {
+  val Algorithm = "ZioK8sTestRSA"
+  val Name = "zio-k8s-test-key-factory"
+}
+
+final class TrackingPublicKey(delegate: PublicKey) extends PublicKey {
+  override def getAlgorithm: String = TrackingProvider.Algorithm
+
+  override def getEncoded: Array[Byte] = delegate.getEncoded
+
+  override def getFormat: String = delegate.getFormat
+}
+
+final class TrackingRsaKeyFactorySpi extends KeyFactorySpi {
+  private lazy val delegate =
+    KeyFactory.getInstance("RSA")
+
+  override protected def engineGeneratePrivate(keySpec: KeySpec): PrivateKey = {
+    TrackingRsaKeyFactorySpi.used.set(true)
+    delegate.generatePrivate(keySpec)
+  }
+
+  override protected def engineGeneratePublic(keySpec: KeySpec): PublicKey =
+    delegate.generatePublic(keySpec)
+
+  override protected def engineGetKeySpec[T <: KeySpec](key: Key, keySpec: Class[T]): T =
+    delegate.getKeySpec(key, keySpec)
+
+  override protected def engineTranslateKey(key: Key): Key =
+    delegate.translateKey(key)
+}
+
+object TrackingRsaKeyFactorySpi {
+  private val used = new AtomicBoolean(false)
+
+  def prepare(): Unit =
+    used.set(false)
+
+  def wasUsed: Boolean = used.get()
+}


### PR DESCRIPTION
## Summary

- Remove the direct Bouncy Castle dependency from `zio-k8s-client`.
- Replace Bouncy Castle PEM parsing with JDK and JCA decoding for unencrypted PKCS#8 `PRIVATE KEY`, PKCS#1 `RSA PRIVATE KEY`, and SEC1 `EC PRIVATE KEY` files.
- Resolve PKCS#8 `KeyFactory` implementations through registered JCA providers using the client certificate's public-key algorithm.
- Use the configured key-entry password consistently when initializing `KeyManagerFactory`.
- Document supported key formats and add regression coverage for key loading and provider resolution.

## Compatibility notes

- Encrypted PEM input remains unsupported, and `K8sAuthentication.ClientCertificates.password` does not decrypt PEM input.
- Traditional `DSA PRIVATE KEY` files are no longer supported. They may be converted to unencrypted PKCS#8 when a registered provider supports DSA.

## Testing

- `KeyManagersSpec` passes on Scala 2.12.21, 2.13.18, and 3.3.7 with JDK 11.0.30, OpenJDK 17.0.19, and Oracle GraalVM JDK 25.0.2.
- `scalafmtCheckAll` passes.
- `git diff --check` passes.

Related to #576, which previously proposed removing the direct Bouncy Castle dependency. This implementation additionally preserves the supported RSA and EC key formats, documents compatibility boundaries, and adds key-loading regression tests.

Fixes #773